### PR TITLE
BAU: Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @govuk-one-login/auth-team
-* @govuk-one-login/auth-leads
-* @govuk-one-login/orchestration-leads
-* @govuk-one-login/orchestration-team
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
Currently, both auth and orch approvals are required to merge to this repo - this should not be the case