### PR TITLE
BAU: update stub to pass sessionId

### DIFF
--- a/orchestration-stub/src/utils/constants.ts
+++ b/orchestration-stub/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const SESSION_ID_HEADER = "Session-Id"


### PR DESCRIPTION
## What:
- Passes sessionId in header to Auth's userinfo endpoint

## Why: 
- This interface was recently updated[1], and the stub now needs to pass this information along to reflect that

[1]- https://github.com/govuk-one-login/authentication-api/commit/4982ca09800e9c751201495c92177145aa0132ce#diff-a02c6800ca638feff17991937c4b9eff5c26039b5c6474a0f5d6a8f02e7c6df5R119


## How to review: 
- Code review commit-by-commit
- Ran through and confirmed it works! https://gds.slack.com/archives/C02KUCT0ZAS/p1727096278613759?thread_ts=1727080348.424269&cid=C02KUCT0ZAS