### PR TITLE
ATO-1062: Adds channel claim to orch stub JAR 

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -127,6 +127,35 @@ const get = (event: APIGatewayProxyEvent): APIGatewayProxyResult => {
             </div>
         </fieldset>
     </div>
+    <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h2 class="govuk-fieldset__heading">
+                Channel
+            </h2>
+        </legend>
+        <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="channel-none" name="channel" type="radio" value="none" checked>
+                <label class="govuk-label govuk-radios__label" for="channel-none">
+                    None
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="channel-web" name="channel" type="radio" value="web">
+                <label class="govuk-label govuk-radios__label" for="channel-web">
+                    Web
+                </label>
+            </div>
+            <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="channel-strategic-app" name="channel" type="radio" value="strategic_app">
+                <label class="govuk-label govuk-radios__label" for="channel-strategic-app">
+                    Strategic App
+                </label>
+            </div>
+        </div>
+    </fieldset>
+    </div>
     <button class="govuk-button">Submit</button>
 </form>
 `;

--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -231,6 +231,9 @@ const jarPayload = (form: RequestParameters, journeyId: string): JWTPayload => {
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];
   }
+  if (form.channel !== "none") {
+    payload["channel"] = form.channel;
+  }
   return payload;
 };
 

--- a/orchestration-stub/src/services/request-parameters.ts
+++ b/orchestration-stub/src/services/request-parameters.ts
@@ -1,11 +1,13 @@
 import querystring, { ParsedUrlQuery } from "querystring";
 import { CredentialTrustLevel } from "../types/credential-trust";
+import { ChannelEnum } from "../types/channel";
 
 export type RequestParameters = {
   confidence: CredentialTrustLevel;
   reauthenticate?: string;
   authenticated: boolean;
   authenticatedLevel?: CredentialTrustLevel;
+  channel: ChannelEnum;
 };
 
 export const parseRequestParameters = (
@@ -23,6 +25,7 @@ export const parseRequestParameters = (
     reauthenticate: getReauthenticate(parsedForm),
     authenticated: existingAuthentication.authenticated,
     authenticatedLevel: existingAuthentication.authenticatedLevel,
+    channel: getChannel(parsedForm.channel),
   };
 };
 
@@ -47,4 +50,16 @@ const getReauthenticate = (form: ParsedUrlQuery): string | undefined => {
   if (typeof form.reauthenticate === "string" && form.reauthenticate !== "") {
     return form.reauthenticate;
   }
+};
+
+const getChannel = (channel: string | string[] | undefined): ChannelEnum => {
+  if (
+    typeof channel === "string" &&
+    (channel === ChannelEnum.NONE ||
+      channel === ChannelEnum.WEB ||
+      channel === ChannelEnum.STRATEGIC_APP)
+  ) {
+    return channel;
+  }
+  throw new Error("Unknown channel: " + channel);
 };

--- a/orchestration-stub/src/types/channel.ts
+++ b/orchestration-stub/src/types/channel.ts
@@ -1,0 +1,1 @@
+export enum ChannelEnum { NONE = "none", WEB = "web" , STRATEGIC_APP = "strategic_app" } ;


### PR DESCRIPTION
## What:
- Adds a new option to the orch stub, for the `channel` claim
- Validates it is one of three options (none, web, strategic_app)
- Attaches to the JAR payload if you have selected an option which is not none

(90% of this work was already done on the branch https://github.com/govuk-one-login/authentication-stubs/tree/BAU/channel-claim, so thanks @dbes-gds!)


## Why: 
- The auth frontend needs this claim to decide which view to render 