### PR TITLE
ATO-980: Adds authenticated claim to JAR

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -198,6 +198,7 @@ const jarPayload = (form: RequestParameters, journeyId: string): JWTPayload => {
     client_id: "orchestrationAuth",
     redirect_uri: `https://${process.env.STUB_DOMAIN}/orchestration-redirect`,
     claim: JSON.stringify(claim),
+    authenticated: form.authenticated ?? false
   };
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];


### PR DESCRIPTION
This adds the authenticated claim to the JAR the stub sends to authorize endpoint. This matches the updates made to this interface in orchestration[1] and means any subsequent reliance on this field won't break the stub.

I've not modified the session setup this stub does because I'm unsure if this modifies the frontend session or the shared backend session.

[1]-https://github.com/govuk-one-login/authentication-api/pull/5310/files