### PR TITLE
BAU: Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
   - package-ecosystem: npm
     directory: "/orchestration-stub/src"
     open-pull-requests-limit: 10
+    groups:
+      npm-babel-dependencies:
+        patterns:
+          - "@babel/*"
     target-branch: main
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
     target-branch: main
     schedule:
       interval: daily
+  - package-ecosystem: npm
+    directory: "/ipv-stub/src"
+    open-pull-requests-limit: 10
+    target-branch: main
+    schedule:
+      interval: daily


### PR DESCRIPTION
### Group `@babel/*` npm dependabot PRs
`@babel/core`, `@babel/preset-env` & `@babel/preset-typescript` are closely related, so grouping them reduces the effort in keeping up-to-date with this set of dependencies


### Add dependabot npm checks for ipv-stub
Ensure dependabot is checking npm dependencies for ipv-stub

