### PR TITLE
Aut 3820/validate body

### DIFF
--- a/ipv-stub/package-lock.json
+++ b/ipv-stub/package-lock.json
@@ -16,14 +16,18 @@
       "devDependencies": {
         "@types/aws-lambda": "8.10.145",
         "@types/aws-sdk": "2.7.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^10.0.7",
         "@types/node": "20.14.0",
         "@typescript-eslint/eslint-plugin": "7.15.0",
         "@typescript-eslint/parser": "7.18.0",
+        "chai": "^4.3.6",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.2.1",
+        "mocha": "10.8.2",
         "prettier": "3.3.3",
-        "ts-node": "10.9.2",
+        "ts-node": "^10.9.2",
         "typescript": "5.6.3"
       },
       "engines": {
@@ -701,6 +705,20 @@
         "aws-sdk": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.9",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.9.tgz",
+      "integrity": "sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.14.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
@@ -1132,6 +1150,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1158,6 +1186,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1180,6 +1222,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/atomic-sleep": {
@@ -1208,9 +1260,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1691.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1691.0.tgz",
-      "integrity": "sha512-/F2YC+DlsY3UBM2Bdnh5RLHOPNibS/+IcjUuhP8XuctyrN+MlL+fWDAiela32LTDk7hMy4rx8MTgvbJ+0blO5g==",
+      "version": "2.1692.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
+      "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1258,6 +1310,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1280,6 +1345,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/buffer": {
       "version": "4.9.2",
@@ -1323,6 +1395,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1338,6 +1442,69 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -1375,9 +1542,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1407,6 +1574,32 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1433,9 +1626,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1467,6 +1660,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -1528,6 +1728,16 @@
         "@esbuild/win32-arm64": "0.24.0",
         "@esbuild/win32-ia32": "0.24.0",
         "@esbuild/win32-x64": "0.24.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1892,6 +2102,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -1931,6 +2151,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1939,6 +2174,26 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1962,9 +2217,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
@@ -1972,12 +2227,11 @@
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1996,28 +2250,17 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -2155,6 +2398,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -2235,6 +2488,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -2256,6 +2522,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2307,6 +2583,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
@@ -2321,6 +2607,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -2437,6 +2736,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -2484,6 +2810,71 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2497,6 +2888,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -2618,6 +3019,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/picomatch": {
@@ -2772,6 +3183,29 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -2779,6 +3213,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2819,6 +3263,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2842,6 +3332,27 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -2870,6 +3381,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/set-function-length": {
@@ -2939,6 +3460,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -3027,9 +3563,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
+      "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3083,10 +3619,20 @@
         }
       }
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
@@ -3101,6 +3647,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -3242,6 +3798,31 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3271,6 +3852,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yn": {

--- a/ipv-stub/package.json
+++ b/ipv-stub/package.json
@@ -15,7 +15,8 @@
     "start:local": "sam local start-api --template build/ipv/template.yaml --env-vars parameters.json -p 3000",
     "compile": "tsc",
     "encryptSampleRequest": "node scripts/encrypt-message-locally.js",
-    "pretty": "prettier --write '**/*.ts' '**/*.js'"
+    "pretty": "prettier --write '**/*.ts' '**/*.js'",
+    "test": "mocha"
   },
   "prettier": {
     "trailingComma": "es5",
@@ -25,17 +26,34 @@
   "devDependencies": {
     "@types/aws-lambda": "8.10.145",
     "@types/aws-sdk": "2.7.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^10.0.7",
     "@types/node": "20.14.0",
     "@typescript-eslint/eslint-plugin": "7.15.0",
     "@typescript-eslint/parser": "7.18.0",
+    "chai": "^4.3.6",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
+    "mocha": "10.8.2",
     "prettier": "3.3.3",
-    "ts-node": "10.9.2",
+    "ts-node": "^10.9.2",
     "typescript": "5.6.3"
   },
   "engines": {
     "node": ">=20.0.0 <21"
+  },
+  "mocha": {
+    "diff": true,
+    "extension": [
+      "js",
+      "ts"
+    ],
+    "timeout": 20000,
+    "recursive": true,
+    "require": [
+      "ts-node/register"
+    ],
+    "exit": true
   }
 }

--- a/ipv-stub/scripts/encrypt-message-locally.js
+++ b/ipv-stub/scripts/encrypt-message-locally.js
@@ -12,22 +12,67 @@ const publicKeyPem = `-----BEGIN PUBLIC KEY-----
   6wIDAQAB
   -----END PUBLIC KEY-----`;
 
-const algorithm = { alg: "some-alg" };
-const payload = { foo: "bar" };
-const signature = { sig: "a-signature" };
+const base64Encode = (s) => {
+  return Buffer.from(s, "utf-8").toString("base64");
+};
 
-const stringToEncrypt = [algorithm, payload, signature]
-  .map((e) => JSON.stringify(e))
-  .map((element) => Buffer.from(element.toString(), "utf-8").toString("base64"))
-  .join(".");
+const createJwt = (header, payload, signature) => {
+  return [header, payload, signature]
+    .map((e) => base64Encode(JSON.stringify(e)))
+    .join(".");
+};
 
-const dataToEncrypt = Uint8Array.from(stringToEncrypt, (c) => c.charCodeAt(0));
+const createUserInfoClaims = () => {
+  const storageAccessTokenSignature = {
+    sig: "a-storage-access-token-signature",
+  };
+
+  const storageAccessTokenAlgorithm = { alg: "some-storage-access-alg" };
+  const storageAccessTokenPayload = {
+    scope: "reverification",
+    aud: [
+      "https://credential-store.test.account.gov.uk",
+      "https://identity.test.account.gov.uk",
+    ],
+    sub: "someSub",
+    iss: "https://oidc.test.account.gov.uk/",
+    exp: 1709051163,
+    iat: 1709047563,
+    jti: "dfccf751-be55-4df4-aa3f-a993193d5216",
+  };
+  return {
+    userinfo: {
+      "https://vocab.account.gov.uk/v1/storageAccessToken": {
+        values: [
+          createJwt(
+            storageAccessTokenAlgorithm,
+            storageAccessTokenPayload,
+            storageAccessTokenSignature
+          ),
+        ],
+      },
+    },
+  };
+};
+
+const createRequestJwt = () => {
+  const algorithm = { alg: "some-alg" };
+  const payload = { scope: "reverification", claims: createUserInfoClaims() };
+  const signature = { sig: "a-signature" };
+
+  return createJwt(algorithm, payload, signature);
+};
+
 (async () => {
+  const dataToEncrypt = Uint8Array.from(createRequestJwt(), (c) =>
+    c.charCodeAt(0)
+  );
+
   const publicKey = await importSPKI(publicKeyPem, "RSA-OAEP-256");
 
-  const jwe = await new CompactEncrypt(dataToEncrypt)
+  const encryptedRequest = await new CompactEncrypt(dataToEncrypt)
     .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
     .encrypt(publicKey);
 
-  console.log("Encrypted (JWE Compact):", jwe);
+  console.log(`Encrypted request:\n------\n${encryptedRequest}`);
 })();

--- a/ipv-stub/scripts/encrypt-message-locally.js
+++ b/ipv-stub/scripts/encrypt-message-locally.js
@@ -1,4 +1,4 @@
-const { CompactEncrypt, importSPKI } = require('jose');
+const { CompactEncrypt, importSPKI } = require("jose");
 
 //This is the public key equivalent of the local private key in parameters.
 // Both have been committed deliberately to allow for local running and testing.
@@ -13,21 +13,21 @@ const publicKeyPem = `-----BEGIN PUBLIC KEY-----
   -----END PUBLIC KEY-----`;
 
 const algorithm = { alg: "some-alg" };
-const payload = { foo: "bar" }
+const payload = { foo: "bar" };
 const signature = { sig: "a-signature" };
 
 const stringToEncrypt = [algorithm, payload, signature]
-    .map(e => JSON.stringify(e))
-    .map(element => Buffer.from(element.toString(), "utf-8").toString("base64"))
-    .join('.');
+  .map((e) => JSON.stringify(e))
+  .map((element) => Buffer.from(element.toString(), "utf-8").toString("base64"))
+  .join(".");
 
-const dataToEncrypt = Uint8Array.from(stringToEncrypt, c => c.charCodeAt(0));
+const dataToEncrypt = Uint8Array.from(stringToEncrypt, (c) => c.charCodeAt(0));
 (async () => {
-    const publicKey = await importSPKI(publicKeyPem, "RSA-OAEP-256");
+  const publicKey = await importSPKI(publicKeyPem, "RSA-OAEP-256");
 
-    const jwe = await new CompactEncrypt(dataToEncrypt)
-        .setProtectedHeader({alg: "RSA-OAEP-256", enc: "A256GCM"})
-        .encrypt(publicKey);
+  const jwe = await new CompactEncrypt(dataToEncrypt)
+    .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+    .encrypt(publicKey);
 
-    console.log("Encrypted (JWE Compact):", jwe);
-})()
+  console.log("Encrypted (JWE Compact):", jwe);
+})();

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -12,7 +12,7 @@ import {
   successfulHtmlResult,
 } from "../helper/result-helper";
 import { compactDecrypt, importPKCS8 } from "jose";
-import { isValidRequest } from "../helper/jwt-validator";
+import { parseRequest } from "../helper/jwt-validator";
 
 export const handler: Handler = async (
   event: APIGatewayProxyEvent
@@ -59,14 +59,15 @@ async function get(
     Buffer.from(part, "base64url").toString("utf8")
   );
 
-  if (!isValidRequest(decodedPayload)) {
-    throw new CodedError(400, "Request parameter invalid");
+  const parsedRequestOrError = parseRequest(decodedPayload);
+
+  if (typeof parsedRequestOrError === "string") {
+    //here in the orch stub they save a code to dynamo. We don't need to do this yet I don't think
+    throw new CodedError(400, parsedRequestOrError);
+  } else {
+    return successfulHtmlResult(
+      200,
+      renderIPVAuthorize(decodedHeader, parsedRequestOrError)
+    );
   }
-
-  //here in the orch stub they save a code to dynamo. We don't need to do this yet I don't think
-
-  return successfulHtmlResult(
-    200,
-    renderIPVAuthorize(decodedHeader, decodedPayload)
-  );
 }

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -12,6 +12,7 @@ import {
   successfulHtmlResult,
 } from "../helper/result-helper";
 import { compactDecrypt, importPKCS8 } from "jose";
+import { isValidRequest } from "../helper/jwt-validator";
 
 export const handler: Handler = async (
   event: APIGatewayProxyEvent
@@ -57,6 +58,10 @@ async function get(
   const [decodedHeader, decodedPayload, _decodedSignature] = parts.map((part) =>
     Buffer.from(part, "base64url").toString("utf8")
   );
+
+  if (!isValidRequest(decodedPayload)) {
+    throw new CodedError(400, "Request parameter invalid");
+  }
 
   //here in the orch stub they save a code to dynamo. We don't need to do this yet I don't think
 

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -11,7 +11,7 @@ import {
   methodNotAllowedError,
   successfulHtmlResult,
 } from "../helper/result-helper";
-import {compactDecrypt, importPKCS8} from "jose";
+import { compactDecrypt, importPKCS8 } from "jose";
 
 export const handler: Handler = async (
   event: APIGatewayProxyEvent

--- a/ipv-stub/src/endpoints/render-ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/render-ipv-authorize.ts
@@ -1,8 +1,9 @@
 import { renderPage } from "../helper/template";
+import { DecodedRequest } from "../helper/types";
 
 export default function renderIPVAuthorize(
   decodedHeader: string,
-  decodedPayload: string
+  decodedPayload: DecodedRequest
 ) {
   return renderPage(
     `<h1 class="govuk-heading-l">IPV stub</h1>
@@ -23,7 +24,7 @@ export default function renderIPVAuthorize(
       Decrypted JAR payload
     </dt>
     <dd class="govuk-summary-list__value" id="user-info-core-identity-claim">
-    <textarea class="govuk-textarea" rows="10" id="identity_claim" name="identity_claim" type="text">${JSON.stringify(JSON.parse(decodedPayload), null, 2)}</textarea>
+    <textarea class="govuk-textarea" rows="10" id="identity_claim" name="identity_claim" type="text">${JSON.stringify(decodedPayload, null, 2)}</textarea>
     </dd>
   </div>
   </dl>`

--- a/ipv-stub/src/helper/jwt-validator.ts
+++ b/ipv-stub/src/helper/jwt-validator.ts
@@ -1,0 +1,45 @@
+export function isValidRequest(requestString: string): boolean {
+  const requestAsJson = JSON.parse(requestString);
+
+  const hasUserInfoClaim = requestAsJson.claims?.userinfo != undefined;
+  return (
+    requestAsJson["scope"] === "reverification" &&
+    hasUserInfoClaim &&
+    validateUserInfoClaim(requestAsJson.claims.userinfo)
+  );
+}
+
+type EncodedUserInfoClaim = {
+  "https://vocab.account.gov.uk/v1/storageAccessToken": {
+    values: string;
+  };
+};
+
+function validateUserInfoClaim(userInfo: EncodedUserInfoClaim): boolean {
+  const hasAccessTokenValues =
+    userInfo["https://vocab.account.gov.uk/v1/storageAccessToken"]?.values !=
+    undefined;
+  if (hasAccessTokenValues) {
+    const parts =
+      userInfo[
+        "https://vocab.account.gov.uk/v1/storageAccessToken"
+      ].values[0].split(".");
+
+    if (parts.length !== 3) {
+      return false;
+    }
+
+    //TODO: need to validate the signature, that to follow this PR
+    const [_decodedHeader, decodedPayload, _decodedSignature] = parts.map(
+      (part) => Buffer.from(part, "base64url").toString("utf8")
+    );
+
+    try {
+      const payloadAsJson = JSON.parse(decodedPayload);
+
+      return payloadAsJson.scope === "reverification";
+    } catch (e) {
+      return false;
+    }
+  } else return false;
+}

--- a/ipv-stub/src/helper/types.ts
+++ b/ipv-stub/src/helper/types.ts
@@ -1,0 +1,26 @@
+export type DecodedRequest = {
+  scope: String;
+  claims: DecodedUserInfoClaim;
+};
+
+export type DecodedUserInfoClaim = {
+  userinfo: {
+    "https://vocab.account.gov.uk/v1/storageAccessToken": {
+      values: [DecodedStorageAccessToken];
+    };
+  };
+};
+
+export type EncodedUserInfoClaim = {
+  "https://vocab.account.gov.uk/v1/storageAccessToken": { values: [string] };
+};
+
+export type DecodedStorageAccessToken = {
+  iss: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  sub: string;
+  scope: string;
+  jti: string;
+};

--- a/ipv-stub/test/helper/jwt-validator.test.ts
+++ b/ipv-stub/test/helper/jwt-validator.test.ts
@@ -1,0 +1,122 @@
+import chai from "chai";
+import { describe } from "mocha";
+import { isValidRequest } from "../../src/helper/jwt-validator";
+
+const expect = chai.expect;
+
+const storageAccessTokenPayload = {
+  scope: "reverification",
+  aud: [
+    "https://credential-store.test.account.gov.uk",
+    "https://identity.test.account.gov.uk",
+  ],
+  sub: "someSub",
+  iss: "https://oidc.test.account.gov.uk/",
+  exp: 1709051163,
+  iat: 1709047563,
+  jti: "dfccf751-be55-4df4-aa3f-a993193d5216",
+};
+
+const encodedStorageAccessTokenPayload = base64Encode(
+  storageAccessTokenPayload
+);
+const encodedStorageAccessHeader =
+  "eyJraWQiOiIwOWRkYjY1ZWIzY2U0MWEzYjczYTJhOTM0ZTM5NDg4NmQyYTIyYjU0ZmQwMzVmYWJlZWM3YWMxYzllYzliNzBiIiwiYWxnIjoiRVMyNTYifQ";
+const encodedSignature =
+  "rpZ2IqMwlFLbZ8a7En-EuQ480zcorvNd-GZcwjlxlK3Twq9J1GNiuj9teSLINP_zmeirx7Y8p3DUYWk_hyRhww";
+
+const validClaims = {
+  userinfo: {
+    "https://vocab.account.gov.uk/v1/storageAccessToken": {
+      values: [
+        `${encodedStorageAccessHeader}.${encodedStorageAccessTokenPayload}.${encodedSignature}`,
+      ],
+    },
+  },
+};
+
+const validSampleJwt = {
+  sub: "commonSubjectIdentifier",
+  iss: "https://signin.account.gov.uk",
+  response_type: "code",
+  client_id: "authReverification",
+  govuk_signin_journey_id: "journey-id",
+  aud: "https://identity.account.gov.uk",
+  nbf: 1196676930,
+  scope: "reverification",
+  claims: validClaims,
+  state: "test-state",
+  redirect_uri: "https://signin.account.gov.uk/reverification-callback",
+  exp: 1196677110,
+  iat: 1196676930,
+  jti: "uuid",
+};
+
+describe("isValidJwt", () => {
+  it("returns true for a valid jwt", () => {
+    expect(isValidRequest(JSON.stringify(validSampleJwt))).to.be.true;
+  });
+
+  const INVALID_CLAIMS_AND_DESCRIPTIONS = [
+    {
+      claims: { claims: validClaims },
+      invalidCaseDescription: "the jwt does not contain a scope field",
+    },
+    {
+      claims: { scope: "reverification" },
+      invalidCaseDescription: "the jwt does not contain a claims field",
+    },
+    {
+      claims: {
+        scope: "reverification",
+        claims: {},
+      },
+      invalidCaseDescription: "the jwt does not contain a userinfo claim",
+    },
+    {
+      claims: {
+        scope: "reverification",
+        claims: {
+          userinfo: {},
+        },
+      },
+      invalidCaseDescription:
+        "the jwt does not contain a storage access token field",
+    },
+  ];
+
+  INVALID_CLAIMS_AND_DESCRIPTIONS.forEach((testCase) => {
+    it(`returns false if ${testCase.invalidCaseDescription}`, () => {
+      expect(isValidRequest(JSON.stringify(testCase.claims))).to.be.false;
+    });
+  });
+
+  it("returns false if the jwt contains an invalid storage access token field", () => {
+    const invalidStorageAccessTokenValues = [
+      "no-dot-separation",
+      "not.enough-parts",
+      "too.many.parts.to.be.valid",
+      "not.base64.encoded",
+      `${encodedStorageAccessHeader}.${base64Encode({ foo: "bar" })}.${encodedSignature}`,
+    ];
+    invalidStorageAccessTokenValues.forEach((invalidStorageAccessToken) => {
+      const jwtWithInvalidStorageAccessToken = {
+        scope: "reverification",
+        claims: {
+          userinfo: {
+            "https://vocab.account.gov.uk/v1/storageAccessToken": {
+              values: [invalidStorageAccessToken],
+            },
+          },
+        },
+      };
+
+      expect(isValidRequest(JSON.stringify(jwtWithInvalidStorageAccessToken)))
+        .to.be.false;
+    });
+  });
+});
+
+function base64Encode(json: Object): String {
+  return Buffer.from(JSON.stringify(json), "utf-8").toString("base64");
+}

--- a/ipv-stub/tsconfig.json
+++ b/ipv-stub/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ES2022",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
     "preserveConstEnums": true,


### PR DESCRIPTION
This:
* performs v1 basic validations on the request parameter sent to the ipv stub (for the moment just checking that the `scope` is `reverification`)
* decodes the storage access token stored in the request and performs the same basic validations
* returns a parsed object that can be used in code

This also adds tests, I haven't added the github action to run these tests as there's an existing branch for this, but this to be added soon.

## How to review

1. Code review
1. Run the tests via `npm run test` while in the ipv stub directory and see that they pass for you
1. Run the ipv stub locally via `npm run build && npm run start:local`. Get a request parameter by also running `npm run encryptSampleRequest`. See that the stub page loads, and that you can see the decoded storage token displayed. Now modify the request that we're encrypting / encoding in /scripts/encrypt-message-locally.js so that the request is invalid in some form. Run `npm run encryptSampleRequest`, and use this to make a request. See that you get some error message that is relevant to the way that your request is invalid.