### PR TITLE
BAU: Add private key for use by the stub to decrypt requests.

### DIFF
--- a/ipv-stub/template.yml
+++ b/ipv-stub/template.yml
@@ -64,8 +64,13 @@ Resources:
       Environment:
         Variables:
           ENVIRONMENT: !Sub ${Environment}
+          IPV_AUTHORIZE_PRIVATE_ENCRYPTION_KEY: "{{resolve:secretsmanager:/dev/stubs/ipv-stub-private-key:SecretString}}"
           IPV_AUTHORIZE_PUBLIC_SIGNING_KEY: ""
-          IPV_AUTHORIZE_PRIVATE_ENCRYPTION_KEY: ""
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action: secretsmanager:GetSecretValue
+              Resource: arn:aws:secretsmanager:eu-west-2:975050272416:secret:/dev/stubs/ipv-stub-private-key-KQsLL3
       Events:
         Get:
           Type: Api


### PR DESCRIPTION
The private key has been created manually initially and is being shared via secrets manager for dev environment only.  The key has been created.

To review:

1. Confirm the key has been created correctly.
2. Confirm the key is set in an environment variable for IPV stub lambda.