### PR TITLE
AUT-3834: Add continue button for ipv stub

### DIFF
--- a/ipv-stub/src/data/ipv-dummy-constants.ts
+++ b/ipv-stub/src/data/ipv-dummy-constants.ts
@@ -1,0 +1,3 @@
+export const AUTH_CODE = "12345";
+
+export const ROOT_URI = `https://signin.${process.env.ENVIRONMENT}.account.gov.uk`;

--- a/ipv-stub/src/endpoints/render-ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/render-ipv-authorize.ts
@@ -27,6 +27,12 @@ export default function renderIPVAuthorize(
     <textarea class="govuk-textarea" rows="10" id="identity_claim" name="identity_claim" type="text">${JSON.stringify(decodedPayload, null, 2)}</textarea>
     </dd>
   </div>
-  </dl>`
+  </dl>
+
+  <form action="/authorize" method="post">
+    <div class="govuk-summary-list__row">
+      <button name="continue" value="continue" class="govuk-button">Continue</button>
+    </div>
+  </form>\``
   );
 }

--- a/ipv-stub/src/helper/result-helper.ts
+++ b/ipv-stub/src/helper/result-helper.ts
@@ -3,14 +3,14 @@ import { logger } from "./logger";
 
 type SuccessCode = 200 | 302;
 type ErrorCode = 400 | 405 | 500;
-type _JsonEntity =
+type JsonEntity =
   | string
   | number
   | boolean
   | null
   | undefined
   | object
-  | _JsonEntity[];
+  | JsonEntity[];
 type Headers = { [header: string]: boolean | number | string };
 
 export class CodedError extends Error {
@@ -31,6 +31,18 @@ export function successfulHtmlResult(
     statusCode: code,
     headers: { ...headers, "Content-Type": "text/html" },
     body: body,
+  };
+}
+
+export function successfulJsonResult(
+  code: SuccessCode,
+  body: JsonEntity,
+  headers?: Headers | undefined
+): APIGatewayProxyResult {
+  return {
+    statusCode: code,
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
   };
 }
 

--- a/ipv-stub/template.yml
+++ b/ipv-stub/template.yml
@@ -78,6 +78,12 @@ Resources:
             RestApiId: !Ref ApiGateway
             Path: /authorize
             Method: get
+        Post:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /authorize
+            Method: post
     Metadata:
       BuildMethod: esbuild
       BuildProperties:


### PR DESCRIPTION
This will initiate the callback logic to the frontend. As part of this we add a post endpoint for the stub which redirects back to the frontend's ipv-callback endpoint. We'll need to further refine the post to ensure that the request has a state that we then retrieve from the database, but for now we just do the simplest thing.