### PR TITLE
BAU: Group all eslint dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
       npm-babel-dependencies:
         patterns:
           - "@babel/*"
-      npm-typescript-eslint-dependencies:
+      npm-eslint-dependencies:
         patterns:
-          - "@typescript-eslint/*"
+          - "*eslint*"
     target-branch: main
     schedule:
       interval: daily
@@ -23,9 +23,9 @@ updates:
     directory: "/ipv-stub/src"
     open-pull-requests-limit: 10
     groups:
-      npm-typescript-eslint-dependencies:
+      npm-eslint-dependencies:
         patterns:
-          - "@typescript-eslint/*"
+          - "*eslint*"
     target-branch: main
     schedule:
       interval: daily


### PR DESCRIPTION
All dependabot PRs for eslint and related dependencies are grouped together.

This allows us to reduce the workload managing closely related dependencies.

A previous attempt grouped typescript-eslint packages, whereas this expands the group for all eslint packages we use.

For example these open PRs at the time of drafting:
- https://github.com/govuk-one-login/authentication-stubs/pull/89
- https://github.com/govuk-one-login/authentication-stubs/pull/88
- https://github.com/govuk-one-login/authentication-stubs/pull/87