### PR TITLE
BAU: Improve dependabot scheduling and targeting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     target-branch: main
     schedule:
       interval: daily
+      time: "03:00"
   - package-ecosystem: npm
     directory: "/orchestration-stub"
     open-pull-requests-limit: 10
@@ -19,6 +20,7 @@ updates:
     target-branch: main
     schedule:
       interval: daily
+      time: "03:00"
   - package-ecosystem: npm
     directory: "/ipv-stub"
     open-pull-requests-limit: 10
@@ -29,3 +31,4 @@ updates:
     target-branch: main
     schedule:
       interval: daily
+      time: "03:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       npm-eslint-dependencies:
         patterns:
           - "*eslint*"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [ "> 20" ]
     target-branch: main
     schedule:
       interval: daily
@@ -28,6 +31,9 @@ updates:
       npm-eslint-dependencies:
         patterns:
           - "*eslint*"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [ "> 20" ]
     target-branch: main
     schedule:
       interval: daily


### PR DESCRIPTION
## What

### Set dependabot to run at 3am
This allows dependency PRs to be available before the working day


### Ask dependabot to ignore types for later major node versions
We currently use Node 20.17, so no need to get PRs to update types to Node 22.

e.g. we have these PRs:
- https://github.com/govuk-one-login/authentication-stubs/pull/104
- https://github.com/govuk-one-login/authentication-stubs/pull/99


## How to review

1. Code Review