### PR TITLE
BAU: Small improvements to localstack DynamoDB management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,6 @@
 # di-authentication-stubs
 
-## Test
+We have two projects in this repo:
 
-Run localstack and execute localstack/provision.sh when starting to create resources.
-
-```bash
-docker compose up
-```
-
-## Connect to DynamoDB with IntelliJ Database Explorer
-
-1) Create a `localstack` AWS profile
-
-```
-> aws configure --profile localstack
-AWS Access Key ID [None]: na
-AWS Secret Access Key [None]: na
-Default region name [None]: eu-west-2
-```
-
-2) Navigate File > New > Datasource > DynamoDB
-3) Submit with:
-   - Host: `localhost`
-   - Port: `4566`
-   - Region: `eu-west-2`
-   - Authentication: `AWS Profile`
-   - Profile: `localstack`
-4) Navigate View > Tool Windows > Database
+- [ipv-stub](./ipv-stub)
+- [orchestration-stub](./orchestration-stub)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ Run localstack and execute localstack/provision.sh when starting to create resou
 ```bash
 docker compose up
 ```
+
+## Connect to DynamoDB with IntelliJ Database Explorer
+
+1) Create a `localstack` AWS profile
+
+```
+> aws configure --profile localstack
+AWS Access Key ID [None]: na
+AWS Secret Access Key [None]: na
+Default region name [None]: eu-west-2
+```
+
+2) Navigate File > New > Datasource > DynamoDB
+3) Submit with:
+   - Host: `localhost`
+   - Port: `4566`
+   - Region: `eu-west-2`
+   - Authentication: `AWS Profile`
+   - Profile: `localstack`
+4) Navigate View > Tool Windows > Database

--- a/ipv-stub/README.md
+++ b/ipv-stub/README.md
@@ -2,17 +2,9 @@
 
 ## Running Locally
 
-For now, you will need a local dynamo db instance running on port 8000, and the table manually created to the following specification:
-
-Name: local-AuthIpvStub-Reverification
-PartitionKey: ReverificationId (string)
-
-There is no sort key or GSIs currently.
-
-It is straightforward to do this via NoSqlWorkbench, via the "DDB local" option.
-
-Future improvements to this should mean we can spin this up via docker and localstack and remove the need for manual configuration.
-
+```bash
+(cd localstack && docker compose up)
+```
 ```bash
 npm run build && npm run start:local
 ```
@@ -36,3 +28,24 @@ The local private key (in _parameters.json_) as well as its public key (in the e
 The key pair was generated fresh and should only be used for testing, both locally and as part of the pre-merge GitHub workflow.
 
 In deployed environments, the private key will be retrieved from AWS Secrets Manager, and the public key from AWS Parameter Store. This key pair is different from the one which has been commited here.
+
+
+## Connect to DynamoDB with IntelliJ Database Explorer
+
+1) Create a `localstack` AWS profile
+
+```
+> aws configure --profile localstack
+AWS Access Key ID [None]: na
+AWS Secret Access Key [None]: na
+Default region name [None]: eu-west-2
+```
+
+2) Navigate File > New > Datasource > DynamoDB
+3) Submit with:
+    - Host: `localhost`
+    - Port: `4566`
+    - Region: `eu-west-2`
+    - Authentication: `AWS Profile`
+    - Profile: `localstack`
+4) Navigate View > Tool Windows > Database

--- a/ipv-stub/localstack/docker-compose.yaml
+++ b/ipv-stub/localstack/docker-compose.yaml
@@ -14,5 +14,5 @@ services:
       - AWS_SECRET_ACCESS_KEY=na
       - AWS_DEFAULT_REGION=eu-west-2
     volumes:
-      - ./localstack/provision.sh:/etc/localstack/init/ready.d/init-aws.sh
+      - ./provision.sh:/etc/localstack/init/ready.d/init-aws.sh
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"

--- a/ipv-stub/localstack/provision.sh
+++ b/ipv-stub/localstack/provision.sh
@@ -40,6 +40,13 @@ create_ipv_stub_table() {
             "S": "test"
           }
         }'
+
+  aws --endpoint-url=$ENDPOINT_URL dynamodb create-table \
+      --table-name local-AuthIpvStub-Reverification \
+      --attribute-definitions AttributeName=ReverificationId,AttributeType=S \
+      --key-schema AttributeName=ReverificationId,KeyType=HASH \
+      --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+      --region "$REGION"
 }
 
 


### PR DESCRIPTION
## What

### Guide IntelliJ Datasource for local DynamoDB
Add README guidance on how to connect to the localstack DynamoDB database with IntelliJ Database Explorer


### Move localstack files to `ipv-stub` directory
Our current localstack implementation is IPV specific, so configuration files and documentation moved to the `ipv-stub` folder.

Part of this was consolidating guidance for creating the local tables, by using docker and adding the Reverification table definition to the provision script.


## How to review

1. Code Review
2. Follow documentation to get a GUI DynamoDB interface to docker managed DynamoDB instance