### PR TITLE
Aut 3681/add more database storing

### DIFF
--- a/ipv-stub/src/data/ipv-dummy-constants.ts
+++ b/ipv-stub/src/data/ipv-dummy-constants.ts
@@ -1,3 +1,1 @@
-export const AUTH_CODE = "12345";
-
 export const ROOT_URI = `https://signin.${process.env.ENVIRONMENT}.account.gov.uk`;

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -73,7 +73,6 @@ async function get(
   const authCode = base64url.encode(randomBytes(32));
 
   if (typeof parsedRequestOrError === "string") {
-    //here in the orch stub they save a code to dynamo. We don't need to do this yet I don't think
     throw new CodedError(400, parsedRequestOrError);
   } else {
     try {

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -81,7 +81,7 @@ async function get(
 
     return successfulHtmlResult(
       200,
-      renderIPVAuthorize(decodedHeader, parsedRequestOrError)
+      renderIPVAuthorize(decodedHeader, parsedRequestOrError, authCode)
     );
   }
 }

--- a/ipv-stub/src/endpoints/ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/ipv-authorize.ts
@@ -14,10 +14,11 @@ import {
 } from "../helper/result-helper";
 import { base64url, compactDecrypt, importPKCS8 } from "jose";
 import { parseRequest } from "../helper/jwt-validator";
-import { AUTH_CODE, ROOT_URI } from "../data/ipv-dummy-constants";
+import { ROOT_URI } from "../data/ipv-dummy-constants";
 import {
   getStateWithAuthCode,
   putStateWithAuthCode,
+  putReverificationWithAuthCode,
 } from "../services/dynamodb-form-response-service";
 import { randomBytes } from "crypto";
 
@@ -116,6 +117,20 @@ async function post(
     }
   } catch (error) {
     throw new CodedError(500, `dynamoDb error: ${error}`);
+  }
+
+  const reverification = {
+    sub: "urn:fdc:gov.uk:2022:fake_common_subject_identifier",
+    success: true,
+  };
+
+  try {
+    await putReverificationWithAuthCode(authCode, reverification);
+  } catch (error) {
+    throw new CodedError(
+      500,
+      `dynamoDb error on storing reverification with auth code: ${error}`
+    );
   }
 
   return Promise.resolve(

--- a/ipv-stub/src/endpoints/render-ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/render-ipv-authorize.ts
@@ -3,7 +3,8 @@ import { DecodedRequest } from "../helper/types";
 
 export default function renderIPVAuthorize(
   decodedHeader: string,
-  decodedPayload: DecodedRequest
+  decodedPayload: DecodedRequest,
+  authCode: string
 ) {
   return renderPage(
     `<h1 class="govuk-heading-l">IPV stub</h1>
@@ -30,6 +31,7 @@ export default function renderIPVAuthorize(
   </dl>
 
   <form action="/authorize" method="post">
+    <input type="hidden" name="authCode" value=${authCode}>
     <div class="govuk-summary-list__row">
       <button name="continue" value="continue" class="govuk-button">Continue</button>
     </div>

--- a/ipv-stub/src/interfaces/reverification-interface.ts
+++ b/ipv-stub/src/interfaces/reverification-interface.ts
@@ -1,0 +1,6 @@
+export interface Reverification {
+  sub: string;
+  success: boolean;
+  error_code?: string;
+  error_description?: boolean;
+}

--- a/ipv-stub/src/services/dynamodb-form-response-service.ts
+++ b/ipv-stub/src/services/dynamodb-form-response-service.ts
@@ -24,6 +24,17 @@ export const putStateWithAuthCode = async (authCode: string, state: string) => {
   });
 };
 
+export const getStateWithAuthCode = async (
+  authCode: string
+): Promise<string> => {
+  const response = await dynamo.get({
+    TableName: tableName,
+    Key: { ReverificationId: authCode + "-state" },
+  });
+
+  return response.Item?.state;
+};
+
 function getOneDayTimestamp() {
   const date = new Date();
   date.setDate(date.getDate() + 1);

--- a/ipv-stub/src/services/dynamodb-form-response-service.ts
+++ b/ipv-stub/src/services/dynamodb-form-response-service.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { Reverification } from "../interfaces/reverification-interface";
 
 const client =
   process.env.ENVIRONMENT === "local"
@@ -35,8 +36,26 @@ export const getStateWithAuthCode = async (
   return response.Item?.state;
 };
 
+export const putReverificationWithAuthCode = async (
+  authCode: string,
+  reverification: Reverification
+) => {
+  return await dynamo.put({
+    TableName: tableName,
+    Item: {
+      ReverificationId: authCode,
+      reverification,
+      ttl: oneHourFromNow(),
+    },
+  });
+};
+
 function getOneDayTimestamp() {
   const date = new Date();
   date.setDate(date.getDate() + 1);
   return Math.floor(date.getTime() / 1000);
+}
+
+function oneHourFromNow() {
+  return Math.floor(Date.now() / 1000) + 3600;
 }

--- a/ipv-stub/src/services/dynamodb-form-response-service.ts
+++ b/ipv-stub/src/services/dynamodb-form-response-service.ts
@@ -20,7 +20,7 @@ export const putStateWithAuthCode = async (authCode: string, state: string) => {
     Item: {
       ReverificationId: authCode + "-state",
       state,
-      ttl: getOneDayTimestamp(),
+      ttl: oneHourFromNow(),
     },
   });
 };
@@ -49,12 +49,6 @@ export const putReverificationWithAuthCode = async (
     },
   });
 };
-
-function getOneDayTimestamp() {
-  const date = new Date();
-  date.setDate(date.getDate() + 1);
-  return Math.floor(date.getTime() / 1000);
-}
 
 function oneHourFromNow() {
   return Math.floor(Date.now() / 1000) + 3600;

--- a/ipv-stub/template.yaml
+++ b/ipv-stub/template.yaml
@@ -146,6 +146,7 @@ Resources:
               Action: secretsmanager:GetSecretValue
               Resource: arn:aws:secretsmanager:eu-west-2:975050272416:secret:/dev/stubs/ipv-stub-private-key-KQsLL3
         - !Ref ReverificationTableWriteAccessPolicy
+        - !Ref ReverificationTableReadAccessPolicy
       Events:
         Get:
           Type: Api
@@ -263,6 +264,18 @@ Resources:
               - dynamodb:PutItem
             Resource: !GetAtt ReverificationTable.Arn
 
+  ReverificationTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowReverificationTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt ReverificationTable.Arn
 # todo ,
 # currently records set and ACM vadiladation is done Manaully in old dev account 
 # Once the signin.dev.account.gov.uk zone is migrated to new dev account we need to bring this is Code 


### PR DESCRIPTION
## What

Finishes off some work started in [this PR](https://github.com/govuk-one-login/authentication-stubs/pull/107) to use dynamo to persist things required for the oauth flow.

Specifically, this:
* Adds the auth code as a hidden input to the form rendered on authorize GET to allow it to be used in the POST
* Uses the auth code from the form submitted to authorize POST to retrieve the state and add to the url parameters sent back in the redirect
* Stores the reverification (currently hardcoded) result in authorize POST against the auth code, which sets up data required for the token endpoint and later the user info (or reverification) endpoint.

## How to review

1. Code Review
1. Run locally. Spin the database up either via localstack or just run locally for now per the PR instructions. See that the flow works and the relevant items are stored.
1. Repeat for deployed env
