### PR TITLE
BAU: Group @aws-sdk/* dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       npm-eslint-dependencies:
         patterns:
           - "*eslint*"
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 20" ]


### PR DESCRIPTION
## What

They tend to be upgraded with the same releases and grouping them should decrease the time it takes to update them as individual PRs.

For example, at the time of writing these PRs are open:
- https://github.com/govuk-one-login/authentication-stubs/pull/121
- https://github.com/govuk-one-login/authentication-stubs/pull/122

## How to review

1. Code Review
