### PR TITLE
BAU: Correct `@aws-sdk/*` grouping location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,6 @@ updates:
       npm-eslint-dependencies:
         patterns:
           - "*eslint*"
-      npm-aws-dependencies:
-        patterns:
-          - "@aws-sdk/*"
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 20" ]
@@ -34,6 +31,9 @@ updates:
       npm-eslint-dependencies:
         patterns:
           - "*eslint*"
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 20" ]


### PR DESCRIPTION
`ipv-stub` uses `@aws-sdk/*` dependencies, not `orchestration-stub`