### PR TITLE
AUT-3690: staging orchstub redirects to signin.staging domain

### DIFF
--- a/orchestration-stub/template.yaml
+++ b/orchestration-stub/template.yaml
@@ -366,7 +366,7 @@ Mappings:
       vpcId: "vpc-0ca40c7d13490419d"
       privateKey: "{{resolve:secretsmanager:stagingsp-orchestration-stub-private-key::::a31a76f2-4209-41e5-8f99-7d318f536985}}"
       authenticationBackendUrl: "https://rr86yg3r28-vpce-0339d04aeb67de9da.execute-api.eu-west-2.amazonaws.com/staging/"
-      authenticationFrontendUrl: "https://signin-sp.staging.account.gov.uk/"
+      authenticationFrontendUrl: "https://signin.staging.account.gov.uk/"
       redisUrl: "{{resolve:secretsmanager:staging-orchestration-stub-redis-url::::bc07829a-baee-4063-a971-430a0a7f4650}}"
       hostedZoneId: "Z02212762LL4X7ZM4JYAT"
       rpClientId: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3"


### PR DESCRIPTION
## What

staging orchstub redirects to signin.staging domain
Issue: [AUT-3690]

## How to review

Once deployed to staging, the acceptance tests stage in the new secure pipeline should pass

[AUT-3690]: https://govukverify.atlassian.net/browse/AUT-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ