### PR TITLE
BAU: Pass credential trust in stub JAR

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -235,6 +235,12 @@ const jarPayload = (form: RequestParameters, journeyId: string): JWTPayload => {
   if (form.channel !== "none") {
     payload["channel"] = form.channel;
   }
+
+  if (form.authenticatedLevel) {
+    payload["current_credential_strength"] = credentialTrustToEnum(
+      form.authenticatedLevel,
+    );
+  }
   return payload;
 };
 


### PR DESCRIPTION
Recent changes[1] mean that Auth no longer derive the current credential strength from the shared session in uplift helper, but instead rely on a claim passed from orchestration and to auth in the JAR. By adding this claim from the form value we should fix uplift using the orch stub.


## What

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related Pull Requests:
[1] - https://github.com/govuk-one-login/authentication-api/pull/5623

