### PR TITLE
AUT-3894: Add cloudformation vars for stub integration in build

### DIFF
--- a/ipv-stub/src/interfaces/reverification-interface.ts
+++ b/ipv-stub/src/interfaces/reverification-interface.ts
@@ -7,7 +7,7 @@ export interface ReverificationFailure {
   sub: string;
   success: false;
   failure_code: string;
-  failure_description: boolean;
+  failure_description: string;
 }
 
 export type Reverification = ReverificationSuccess | ReverificationFailure;

--- a/ipv-stub/template.yaml
+++ b/ipv-stub/template.yaml
@@ -27,6 +27,11 @@ Mappings:
       hostedZoneId: "Z10132222WVQ7U47816SI"
       authPublicSigningKeyEvcs: "-----BEGIN PUBLIC KEY-----MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExAt6xsHUZdhfX2QcNs9es2dF3UTli3fjvMj4NgIgS1VCrxShBZIpuWEH3HLq7EB3a0N+ARh/xjWJoaYBYcDpDw==-----END PUBLIC KEY-----"
       authPublicSigningKeyIpv: "-----BEGIN PUBLIC KEY-----MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDn0sV329oTHdahzIuUSWS2xw5GVEIKUQ9FPvvEDsNKofkw3n7hy1orQQ0XucyhLAcJy0mofJ3fwbjIZEgKBfUw==-----END PUBLIC KEY-----"
+    build:
+      ipvStubDomainName: ipvstub.signin.build.account.gov.uk
+      hostedZoneId: "Z099220113UW2JSCXBNRI"
+      authPublicSigningKeyEvcs: "-----BEGIN PUBLIC KEY-----MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZd7sKpglYci7vYylf1BnuzD2jLNDvd1k7Fe7SeBcflPsGTwmQ+ixmYOLw3g8DXKtyup1SaIeqPLj/y2TqINDZA==-----END PUBLIC KEY-----"
+      authPublicSigningKeyIpv: "-----BEGIN PUBLIC KEY-----MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGqXe8d+FIbe4ZvdYWwplSoOfNKjNEWQFkMXYD6MPmfc9QRx5a+LFSKU2vUaN79+MXkG9kjvfFcQCaucvQszXaw==-----END PUBLIC KEY-----"
 
 Conditions:
   UseCodeSigning: !Not [!Equals [none, !Ref CodeSigningConfigArn]]


### PR DESCRIPTION
## What

Still need to add IPV_AUTHORIZE_PRIVATE_ENCRYPTION_KEY to secrets manager, and also add per-environment reference to the secret in the cloudformation template

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Related Pull Requests
