### PR TITLE
AUT-3924: Add link to test cross browser

### DIFF
--- a/ipv-stub/src/endpoints/render-ipv-authorize.ts
+++ b/ipv-stub/src/endpoints/render-ipv-authorize.ts
@@ -1,5 +1,6 @@
 import { renderPage } from "../helper/template";
 import { DecodedRequest } from "../helper/types";
+import { ROOT_URI } from '../data/ipv-dummy-constants';
 
 export default function renderIPVAuthorize(
   decodedHeader: string,
@@ -73,6 +74,11 @@ export default function renderIPVAuthorize(
     <div class="govuk-summary-list__row">
       <button name="continue" value="continue" class="govuk-button">Continue</button>
     </div>
-  </form>\``
+  </form>
+  
+  <div class="govuk-inset-text">
+    To test the cross browser issue, open the following in a new private window: <a href="${ROOT_URI}/ipv/callback/authorize?state=${decodedPayload.state}&error=access_denied">${ROOT_URI}/ipv/callback/authorize?state=${decodedPayload.state}&error=access_denied</a>
+  </div>
+  `
   );
 }


### PR DESCRIPTION
## What
Add a link to the bottom of the IPV stub page to test cross browser
<img width="945" alt="image" src="https://github.com/user-attachments/assets/48b6e80f-3aa9-4536-acbc-f85b778f2a1e" />
