### PR TITLE
AUT-4064: update ipv private key with new reference

### DIFF
--- a/ipv-stub/template.yaml
+++ b/ipv-stub/template.yaml
@@ -64,7 +64,7 @@ Mappings:
     build:
       ipvStubDomainName: ipvstub.signin.build.account.gov.uk
       hostedZoneId: "Z09720813AWZDQSXZBWKJ"
-      ipvprivateencryptionkey: "{{resolve:secretsmanager:/build/stubs/ipv-stub-private-key::::b0570d70-75ea-447a-929d-d678c39ede1c}}"
+      ipvprivateencryptionkey: "{{resolve:secretsmanager:/build/stubs/ipv-stub-private-key::::1c764b26-dbfe-488a-aacc-c33a33cdf7ee}}"
       authpublicsigningkeyevcs: "{{resolve:secretsmanager:/build/stubs/auth-evcs-public-signing-key::::3ef9f3d5-1599-4bc6-b2f8-4584496fc5b1}}"
       authpublicsigningkeyipv: "{{resolve:secretsmanager:/build/stubs/auth-reverification-public-signing-key::::2fb4142c-bdaf-4c7d-8b25-4f025848020e}}"
 


### PR DESCRIPTION
## What

- The public key has been updated in the authentication API for build.
- The secret has been updated in the secrets manager.
- This commit updates the reference to that of the new secret.

## How to review

1. Code Review

## Related Pull Requests
