### PR TITLE
BAU: Fix Sub

### DIFF
--- a/ipv-stub/src/endpoints/ipv-token.ts
+++ b/ipv-stub/src/endpoints/ipv-token.ts
@@ -175,8 +175,6 @@ async function handle(
 
   const validatedClaims: Partial<JwtPayload> = parsedClaims.value;
 
-  reverificationResult.sub = <string>validatedClaims["sub"];
-
   const result: PutCommandOutput = await putReverificationWithAccessToken(
     accessToken,
     reverificationResult


### PR DESCRIPTION
## What

- Reverification result sub was being reassigned in the IPV stub to the client sub passed over from ReverificationResultHandler in auth API
- - - The client sub is the same as the issuer in the claims set passed over in the token request in the ReverificationResultHandler in the auth API (example [here](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/master/src/main/java/com/nimbusds/oauth2/sdk/auth/JWTAuthenticationClaimsSet.java))

- This was causing the validation errors in the ReverificationResultHandler as we were expecting a user's sub in the response from the ReverificationResult, not the client sub

## How to review

1. Code Review


