### PR TITLE
ATO-1435: Rename vtr_lst field to vtr

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -272,7 +272,7 @@ const jarPayload = (
     redirect_uri: `https://${process.env.STUB_DOMAIN}/orchestration-redirect`,
     claim: JSON.stringify(claim),
     authenticated: form.authenticated ?? false,
-    vtr_list: `[${form.confidence}]`,
+    vtr: `["${form.confidence}"]`,
     scope: "openid email phone",
   };
   if (form["reauthenticate"] !== "") {


### PR DESCRIPTION
## What

We're changing the name of the `vtr_list` field to just `vtr`, and changing the format to a string to a list, in orch. This is just reflecting this change in the stub.

## Related Pull Requests
Change in orch: https://github.com/govuk-one-login/authentication-api/pull/6224