### PR TITLE
ATO-1422: Send required claims instead of full vtr list

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -273,8 +273,8 @@ const jarPayload = (
     redirect_uri: `https://${process.env.STUB_DOMAIN}/orchestration-redirect`,
     claim: JSON.stringify(claim),
     authenticated: form.authenticated ?? false,
-    vtr: [`${form.confidence}`],
     scope: "openid email phone",
+    requested_credential_strength: form.confidence,
   };
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];


### PR DESCRIPTION
## What

We have changed the claims we are sending from orch to auth frontend. This is updating the stub to reflect these changes.

In short: Instead of `vtr`, we will use `requested_credential_strength`, and since there are no identity journeys in the stub, the `requested_level_of_confidence` is left out of the JAR. 

Note that we would like to get rid of the `confidence` claim we get from orch. In the backend changes, we added another claim called `requested_credential_strength` which we can update the frontend to use. These 2 claims are set to the same value in orch. Once we've swapped to using the new claim with the better name, we can remove the old claim in orch.

For things to not break though, we need to keep sending the `confidence` claim until we remove it from the list of required fields in the frontend.

## How to review

Small enough to review in one commit.
Tested in authdev, stub sends the right fields to auth frontend

## Related Pull Requests
The changes to orch we are trying to reflect: https://github.com/govuk-one-login/authentication-api/pull/6297 
