### PR TITLE
AUT-4300: New Authdev1,2 orchstub instances that integrate with new auth-ext-api

### DIFF
--- a/orchestration-stub/samconfig.toml
+++ b/orchestration-stub/samconfig.toml
@@ -10,21 +10,23 @@ parameter_overrides = "Environment=\"sandpit\""
 image_repositories = []
 
 [authdev1.deploy.parameters]
-stack_name = "authdev1-orch-stub"
-resolve_s3 = true
-s3_prefix = "authdev1-orch-stub"
+stack_name = "authdev1-sp-orch-stub"
+resolve_s3 = false
+s3_bucket = "authdev1-sp-orch-stub-pip-githubartifactsourcebuck-7x2zgverkhya"
 region = "eu-west-2"
-confirm_changeset = false
+confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "Environment=\"dev\" SubEnvironment=\"old-authdev1\""
+parameter_overrides = "CodeSigningConfigArn=\"arn:aws:lambda:eu-west-2:653994557586:code-signing-config:csc-0b1375978ffa2443e\" Environment=\"dev\" SubEnvironment=\"old-authdev1\" PermissionsBoundary=\"arn:aws:iam::653994557586:policy/authdev1-sp-orch-stub-pipeline-AppPermissionsBoundary-02499872cb5f\""
 image_repositories = []
+signing_profiles = "IndexFunction=\"SigningProfile_CA9d6RmKsM4d\" CallbackFunction=\"SigningProfile_CA9d6RmKsM4d\""
 
 [authdev2.deploy.parameters]
-stack_name = "authdev2-orch-stub"
-resolve_s3 = true
-s3_prefix = "authdev2-orch-stub"
+stack_name = "authdev2-sp-orch-stub"
+resolve_s3 = false
+s3_bucket = "authdev2-sp-orch-stub-pip-githubartifactsourcebuck-ebuj1e05ka3c"
 region = "eu-west-2"
-confirm_changeset = false
+confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "Environment=\"dev\" SubEnvironment=\"old-authdev2\""
+parameter_overrides = "CodeSigningConfigArn=\"arn:aws:lambda:eu-west-2:653994557586:code-signing-config:csc-0bde508d034b8a4e7\" Environment=\"dev\" SubEnvironment=\"old-authdev2\" PermissionsBoundary=\"arn:aws:iam::653994557586:policy/authdev2-sp-orch-stub-pipeline-AppPermissionsBoundary-0a0f6a95fa6b\""
 image_repositories = []
+signing_profiles = "CallbackFunction=\"SigningProfile_CA9d6RmKsM4d\" IndexFunction=\"SigningProfile_CA9d6RmKsM4d\""

--- a/orchestration-stub/template.yaml
+++ b/orchestration-stub/template.yaml
@@ -146,7 +146,7 @@ Mappings:
       defaultProvisionedConcurrency: 0
       lambdaMemorySize: "128"
 
-    authdev1:
+    old-authdev1:
       cookieDomain: .dev.account.gov.uk
       stubDomain: orchstub-authdev1.signin.dev.account.gov.uk
       authPubKey: |
@@ -174,9 +174,9 @@ Mappings:
       rpSectorHost: "rp-dev.build.stubs.account.gov.uk"
       lambdaMemorySize: "128"
 
-    old-authdev1:
-      cookieDomain: .authdev1.sandpit.account.gov.uk
-      stubDomain: orchstub.authdev1.sandpit.account.gov.uk
+    authdev1:
+      cookieDomain: .authdev1.dev.account.gov.uk
+      stubDomain: orchstub.signin.authdev1.dev.account.gov.uk
       authPubKey: |
         -----BEGIN PUBLIC KEY-----
         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs0gyWacjheeaMslIDBdf
@@ -187,22 +187,22 @@ Mappings:
         wxACgcz//hhZ9O1h3Kt6BTyvhqZ00FwO//2bdosdX9kjCC+bRCwlUToIY0CmzOFO
         kwIDAQAB
         -----END PUBLIC KEY-----
-      subnetAId: "subnet-04234e8fb1ee28d2c"
-      subnetBId: "subnet-0c91be3c7426cf2e6"
-      subnetCId: "subnet-078749ec82aa5af94"
-      endpointSgId: "sg-0e554161114407ce2"
+      subnetAId: "subnet-0c6f6e7abc765bd57"
+      subnetBId: "subnet-04a0851b2083a2782"
+      subnetCId: "subnet-0c0c7f285b1ef1378"
+      endpointSgId: "sg-0903a817986dc39ef"
       redisSgId: "sg-0eae375db6b4bebb1"
-      vpcId: "vpc-04918b35a66969280"
-      privateKey: "{{resolve:secretsmanager:authdev1-orchestration-stub-private-key::::ca3923ea-99ba-4e9f-8088-f050e45d5aef}}"
-      authenticationBackendUrl: "https://l31ra96lnc-vpce-01a1f8e880d273ec6.execute-api.eu-west-2.amazonaws.com/authdev1/"
-      authenticationFrontendUrl: "https://signin.authdev1.sandpit.account.gov.uk/"
-      redisUrl: "{{resolve:secretsmanager:authdev1-orchestration-stub-redis-url::::805bf5c2-85fe-4042-bedc-2d0d93b4b91d}}"
-      hostedZoneId: "Z062000928I8D7S9X1OVA"
+      vpcId: "vpc-0ad3a83e46742a372"
+      privateKey: "{{resolve:secretsmanager:authdev1-orchestration-stub-private-key::::6f903965-2ce9-4a6e-bfe6-9fe27d12db56}}"
+      authenticationBackendUrl: "https://71gp8u9pgg-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev1/"
+      authenticationFrontendUrl: "https://signin.authdev1.dev.account.gov.uk/"
+      redisUrl: "{{resolve:secretsmanager:authdev1-orchestration-stub-redis-url::::5908ca87-432a-43d6-bb8c-f9b88e2af208}}"
+      hostedZoneId: "Z01488663SVMGDFYGEX88"
       rpClientId: "skwdHH2y6ERjJWTPSoAFbSt8lX04OgtI"
       rpSectorHost: "rp-dev.build.stubs.account.gov.uk"
       lambdaMemorySize: "128"
 
-    authdev2:
+    old-authdev2:
       cookieDomain: .dev.account.gov.uk
       stubDomain: orchstub-authdev2.signin.dev.account.gov.uk
       authPubKey: |
@@ -230,9 +230,9 @@ Mappings:
       rpSectorHost: "rp-dev.build.stubs.account.gov.uk"
       lambdaMemorySize: "128"
 
-    old-authdev2:
-      cookieDomain: .authdev2.sandpit.account.gov.uk
-      stubDomain: orchstub.authdev2.sandpit.account.gov.uk
+    authdev2:
+      cookieDomain: .authdev2.dev.account.gov.uk
+      stubDomain: orchstub.signin.authdev2.dev.account.gov.uk
       authPubKey: |
         -----BEGIN PUBLIC KEY-----
         MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuO+7VuYnfrI1q3FR9IbD
@@ -243,17 +243,17 @@ Mappings:
         R8JLAPX4gEUilflULbVG/JZTulPOyGrDyR656sbh7yuE/rTQBnNSrBibJaAGjlQb
         DQIDAQAB
         -----END PUBLIC KEY-----
-      subnetAId: "subnet-04234e8fb1ee28d2c"
-      subnetBId: "subnet-0c91be3c7426cf2e6"
-      subnetCId: "subnet-078749ec82aa5af94"
-      endpointSgId: "sg-0e554161114407ce2"
+      subnetAId: "subnet-0c6f6e7abc765bd57"
+      subnetBId: "subnet-04a0851b2083a2782"
+      subnetCId: "subnet-0c0c7f285b1ef1378"
+      endpointSgId: "sg-0903a817986dc39ef"
       redisSgId: "sg-09a7840296f9f236e"
-      vpcId: "vpc-04918b35a66969280"
-      privateKey: "{{resolve:secretsmanager:authdev2-orchestration-stub-private-key::::a008a0fa-23dd-4e2f-b9ab-7494e65f60ec}}"
-      authenticationBackendUrl: "https://8yikw2kek6-vpce-01a1f8e880d273ec6.execute-api.eu-west-2.amazonaws.com/authdev2/"
-      authenticationFrontendUrl: "https://signin.authdev2.sandpit.account.gov.uk/"
-      redisUrl: "{{resolve:secretsmanager:authdev2-orchestration-stub-redis-url::::17471c88-d25a-4e85-b075-5c703ee6db92}}"
-      hostedZoneId: "Z062001013DJY2F0YXEJR"
+      vpcId: "vpc-0ad3a83e46742a372"
+      privateKey: "{{resolve:secretsmanager:authdev2-orchestration-stub-private-key::::dbc5daa9-f92c-4450-b801-29ed5e91e126}}"
+      authenticationBackendUrl: "https://rqdauafdhd-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev2/"
+      authenticationFrontendUrl: "https://signin.authdev2.dev.account.gov.uk/"
+      redisUrl: "{{resolve:secretsmanager:authdev2-orchestration-stub-redis-url::::75b26f7c-5e9c-4f17-bac4-0660e5c2a284}}"
+      hostedZoneId: "Z0283478G72QVGV7VVBG"
       rpClientId: "rPEUe0hRrHqf0i0es1gYjKxE5ceGN7VK"
       rpSectorHost: "rp-dev.build.stubs.account.gov.uk"
       lambdaMemorySize: "128"


### PR DESCRIPTION
## What

New Authdev1,2 instances that integrate with the new auth-ext-api.
URLs:
https://orchstub.signin.authdev1.dev.account.gov.uk/
https://orchstub.signin.authdev2.dev.account.gov.uk/

Redefine old account authdev stubs as 'old-' stubs and deployment managed manually via CLI.
New strategic account authdev stubs are deployed via pipeline.

Issues: [AUT-4300], [AUT-4303]

[AUT-4300]: https://govukverify.atlassian.net/browse/AUT-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-4303]: https://govukverify.atlassian.net/browse/AUT-4303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ