### PR TITLE
ATO-1650: Stop sending confidence claim in orch stub

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -267,7 +267,6 @@ const jarPayload = (
     is_one_login_service: false,
     service_type: "essential",
     govuk_signin_journey_id: journeyId,
-    confidence: form.confidence,
     state: "3",
     client_id: "orchestrationAuth",
     redirect_uri: `https://${process.env.STUB_DOMAIN}/orchestration-redirect`,


### PR DESCRIPTION
## What

We have stopped sending the `confidence` claim in orch. This is updating the stub to reflect this change.

Have deployed and performed a couple of journeys in authdev. Waiting to test and merge the actual change into orch: https://github.com/govuk-one-login/authentication-api/pull/6508
