### PR TITLE
ATO-1621: Remove sending current credential strength from stub

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -107,26 +107,6 @@ const get = (_event: APIGatewayProxyEvent): APIGatewayProxyResult => {
                         common subject identifier are set on the session
                     </div>
                 </div>
-                <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                     id="conditional-authenticated-2">
-                    <div class="govuk-form-group govuk-radios" data-module="govuk-radios">
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input govuk-!-width-one-third" id="authenticated-level"
-                                   name="authenticatedLevel" type="radio" value="Cl">
-                            <label class="govuk-label govuk-radios__label" for="authenticated-level">
-                                Low level
-                            </label>
-                        </div>
-                        <div class="govuk-radios__item">
-                            <input class="govuk-radios__input govuk-!-width-one-third" id="authenticated-level-2"
-                                   name="authenticatedLevel" type="radio" value="Cl.Cm" checked>
-                            <label class="govuk-label govuk-radios__label" for="authenticated-level-2">
-                                Medium level
-                            </label>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </fieldset>
     </div>
     <div class="govuk-form-group">
@@ -298,11 +278,7 @@ const jarPayload = (
   if (form.channel !== "none") {
     payload["channel"] = form.channel;
   }
-  if (form.authenticatedLevel) {
-    payload["current_credential_strength"] = credentialTrustToEnum(
-      form.authenticatedLevel,
-    );
-  }
+
   if (previousSessionId) {
     payload["previous_session_id"] = previousSessionId;
   }
@@ -401,9 +377,6 @@ const createNewSession = async (id: string, config: RequestParameters) => {
     session_id: id,
     code_request_count_map: {},
     authenticated: config.authenticated,
-    current_credential_strength: credentialTrustToEnum(
-      config.authenticatedLevel,
-    ),
     is_new_account: AccountStateEnum.UNKNOWN,
   };
   const client = await getRedisClient();
@@ -420,9 +393,6 @@ const renameExistingSession = async (
   await client.del(existingSessionId);
   existingSession.session_id = newSessionId;
   existingSession.authenticated = config.authenticated;
-  existingSession.current_credential_strength = credentialTrustToEnum(
-    config.authenticatedLevel,
-  );
   await client.setEx(newSessionId, 3600, JSON.stringify(existingSession));
 };
 

--- a/orchestration-stub/src/services/request-parameters.ts
+++ b/orchestration-stub/src/services/request-parameters.ts
@@ -6,7 +6,6 @@ export type RequestParameters = {
   confidence: CredentialTrustLevel;
   reauthenticate?: string;
   authenticated: boolean;
-  authenticatedLevel?: CredentialTrustLevel;
   channel: ChannelEnum;
   cookieConsent: string;
   loginHint?: string;
@@ -21,15 +20,13 @@ export const parseRequestParameters = (
 
   const parsedForm = querystring.parse(body);
 
-  const existingAuthentication = getExistingAuthentication(parsedForm);
   return {
     confidence: validateCredentialTrustLevel(parsedForm.level),
     reauthenticate: getReauthenticate(parsedForm),
-    authenticated: existingAuthentication.authenticated,
-    authenticatedLevel: existingAuthentication.authenticatedLevel,
+    authenticated: parsedForm.authenticated === "yes",
     channel: getChannel(parsedForm.channel),
-    cookieConsent: parsedForm["cookie-consent"],
-    loginHint: parsedForm["login-hint"],
+    cookieConsent: parsedForm["cookie-consent"] as string,
+    loginHint: parsedForm["login-hint"] as string | undefined,
   };
 };
 
@@ -40,14 +37,6 @@ const validateCredentialTrustLevel = (
     return level;
   }
   throw new Error("Unknown level " + level);
-};
-
-const getExistingAuthentication = (form: ParsedUrlQuery) => {
-  const authenticated = form.authenticated === "yes";
-  const authenticatedLevel = authenticated
-    ? validateCredentialTrustLevel(form.authenticatedLevel)
-    : undefined;
-  return { authenticated, authenticatedLevel };
 };
 
 const getReauthenticate = (form: ParsedUrlQuery): string | undefined => {


### PR DESCRIPTION
## What: 
Authentication no longer rely on this value being sent from orchestration and instead keep this value is more accurately tracked on the session via Achieved Credential Strength.

We can therefore remove this field

## How to review: 
- Code review commit
- Deployed to authdev1 and ran through an uplift journey (Cl + not authenticated) then chose Cl.Cm and authenticated and was prompted for an MFA code

## Related Pull Requests
