### PR TITLE
AUT-4297: rename mobile channel to generic app channel

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -136,9 +136,9 @@ const get = (_event: APIGatewayProxyEvent): APIGatewayProxyResult => {
                 </label>
             </div>
             <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="channel-mobile" name="channel" type="radio" value="mobile">
-                <label class="govuk-label govuk-radios__label" for="channel-mobile">
-                    Mobile
+                <input class="govuk-radios__input" id="channel-generic-app" name="channel" type="radio" value="generic-app">
+                <label class="govuk-label govuk-radios__label" for="channel-generic-app">
+                    Generic App
                 </label>
             </div>
         </div>

--- a/orchestration-stub/src/services/request-parameters.ts
+++ b/orchestration-stub/src/services/request-parameters.ts
@@ -51,7 +51,7 @@ const getChannel = (channel: string | string[] | undefined): ChannelEnum => {
     (channel === ChannelEnum.NONE ||
       channel === ChannelEnum.WEB ||
       channel === ChannelEnum.STRATEGIC_APP ||
-      channel === ChannelEnum.MOBILE)
+      channel === ChannelEnum.GENERIC_APP)
   ) {
     return channel;
   }

--- a/orchestration-stub/src/types/channel.ts
+++ b/orchestration-stub/src/types/channel.ts
@@ -2,5 +2,5 @@ export enum ChannelEnum {
   NONE = "none",
   WEB = "web",
   STRATEGIC_APP = "strategic_app",
-  MOBILE = "mobile",
+  GENERIC_APP = "generic_app",
 }


### PR DESCRIPTION
## What
Rename "mobile" channel to "generic-app" channel. This channel is currently not in use, so is safe to change.

## How to review
N/A

I have seen that mobile comes on the screen as expected in the original PR. This will also be tested when we test how auth handles this channel.

## Related Pull Requests
Original PR: https://github.com/govuk-one-login/authentication-stubs/pull/349