### PR TITLE
ATO-1679: Add is_smoke_test claim to orch stub

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -271,6 +271,7 @@ const jarPayload = (
     authenticated: form.authenticated ?? false,
     scope: "openid email phone",
     requested_credential_strength: form.confidence,
+    is_smoke_test: false,
   };
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];


### PR DESCRIPTION
## What

Adds the claim `is_smoke_test` claim to the orch stub.

## Related Pull Requests
Change we are replicating: https://github.com/govuk-one-login/authentication-api/pull/6592
