### PR TITLE
ATO-1686: Add subject_type claim to orch stub

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -272,6 +272,7 @@ const jarPayload = (
     scope: "openid email phone",
     requested_credential_strength: form.confidence,
     is_smoke_test: false,
+    subject_type: "pairwise",
   };
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];


### PR DESCRIPTION
## What

Adds the claim `subject_type` to the orch stub

## Related Pull Requests
Change we are replicating: https://github.com/govuk-one-login/authentication-api/pull/6605