### PR TITLE
BAU: Relax `gs` cookie requirement for orch stub

### DIFF
--- a/orchestration-stub/src/utils/constants.ts
+++ b/orchestration-stub/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const SESSION_ID_HEADER = "Session-Id";


### PR DESCRIPTION
## What

Running the frontend locally uses the orch stub in dev environments. It makes a request to the stub and forwards the user with the retuned the query string to our local frontend server. Once auth has completed locally, we are redirected back to the orch stub. Not a local version of the stub, but an online stub for the environment.

Due to cookie restrictions on hostname, the cookie is being set by our local orch stub proxy to localhost, not the hosted domain of the stub. So when we are redirected back to the hosted stub it cannot access the cookie set.

Currently this means we return a 500 error from the stub. Instead lets fail gracefully as there is still useful info from the UserInfo endpoint (that can facilitate a local reauth journey).

TL/DR: Can't get the session? Don't show session data rather than erroring.

## How to review

1. Code Review