### PR TITLE
ATO-1607: add is_identity_verification_required to orch stub

### DIFF
--- a/orchestration-stub/src/index/index.ts
+++ b/orchestration-stub/src/index/index.ts
@@ -273,6 +273,7 @@ const jarPayload = (
     requested_credential_strength: form.confidence,
     is_smoke_test: false,
     subject_type: "pairwise",
+    is_identity_verification_required: false,
   };
   if (form["reauthenticate"] !== "") {
     payload["reauthenticate"] = form["reauthenticate"];


### PR DESCRIPTION
## What

Adds is_identity_verification_required to orch stub.

## Related Pull Requests

https://github.com/govuk-one-login/authentication-api/pull/6655