### PR TITLE
AUT-4539: Production orchstub linking with apitest instances

### DIFF
--- a/orchestration-stub/template.yaml
+++ b/orchestration-stub/template.yaml
@@ -19,6 +19,7 @@ Parameters:
       - build
       - staging
       - integration
+      - production
       - dev-apitest     # not a recognizable environment to secure pipelines
       - build-apitest   # not a recognizable environment to secure pipelines
       - staging-apitest # not a recognizable environment to secure pipelines
@@ -458,15 +459,41 @@ Mappings:
       subnetBId: "subnet-0a36dbbd771a6b262"
       subnetCId: "subnet-08c27975e04e98a72"
       endpointSgId: "sg-0a2b2f093fc81a2ec"
-      redisSgId: "sg-018bd4640f5842d31"
       vpcId: "vpc-04796e8a5bf41b046"
       privateKey: "{{resolve:secretsmanager:integration-orchestration-stub-private-key::::f04a5553-cc9d-46d5-84bc-61191729bb05}}"
       authenticationBackendUrl: "https://5wcpjlfg3i-vpce-0df10df14d851e1c9.execute-api.eu-west-2.amazonaws.com/integration/"
       authenticationFrontendUrl: "https://apitest.signin.integration.account.gov.uk/"
-      redisUrl: "{{resolve:secretsmanager:integration-orchestration-stub-redis-url::::595fef6e-d156-454b-88b5-56245f916e80}}"
       hostedZoneId: "Z0653856BRBXRB77AUXG"
       rpClientId: "gjWNvoLYietMjeaOE6Zoww533u18ZUfr"
       rpSectorHost: "rp-integration.build.stubs.account.gov.uk"
+      defaultProvisionedConcurrency: 3
+      lambdaMemorySize: "1536"
+
+    production:
+      accessViaVPNOnly: "Yes"
+      cookieDomain: .account.gov.uk
+      stubDomain: orchstub.signin.account.gov.uk
+      authPubKey: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAppKCOhyLiKs5QTB1L+XK
+        Tgs9kosxma0PuagvNkP+UEPd0KumWc4sWlYUzR1D1aPX8AGDSQ1awOIb7PhlE5Ss
+        5LilounpT9Pi+FvHFlGKgQzRO63j9CRXzYxhgHGpruzAAKUQ+6D0cuOdao3YF0zz
+        RmaMSdHB4HsNhxV5DHY+2Rr7GeEfl6lQB8EHTAQzoagsIxihxNieUIGhHcegbCv6
+        X5aV67lUEbjjfvGu888GL8qJakOPNoIn/pMBB5LIKVxbyoCB9nfFZ5fPFxBpLdvy
+        p0qsf76XAFuA3nhupIqkXl8jOIDN3U79V1kAgyS8uoilhhblqAtCoJElEiDYQh1M
+        NQIDAQAB
+        -----END PUBLIC KEY-----
+      subnetAId: "subnet-033f6cf615050a93b"
+      subnetBId: "subnet-0038177d6fd032bc2"
+      subnetCId: "subnet-0aa20b375a90748ac"
+      endpointSgId: "sg-088824a661643698d"
+      vpcId: "vpc-06a7d758af9eefddb"
+      privateKey: "{{resolve:secretsmanager:production-orchestration-stub-private-key::::e4ad40c1-ac76-4506-8b2d-0e386c277fac}}"
+      authenticationBackendUrl: "https://9k68v07tz7-vpce-0db136878c87bf2d0.execute-api.eu-west-2.amazonaws.com/production"
+      authenticationFrontendUrl: "https://apitest.signin.account.gov.uk/"
+      hostedZoneId: "Z09365913VV9SM5DYAJBZ"
+      rpClientId: "5Vfplamzln0AoarlnX5CX4UTqyh59xfA"
+      rpSectorHost: "rp.stubs.account.gov.uk"
       defaultProvisionedConcurrency: 3
       lambdaMemorySize: "1536"
 


### PR DESCRIPTION
## What

Production orchstub configurations
Links with apitest frontend and auth-external-api deployed to new auth production environment



