### PR TITLE
BAU: expose node_modules/.bin to GITHUB_PATH so SAM can find esbuild

### DIFF
--- a/.github/workflows/build-deploy-amc-stub.yaml
+++ b/.github/workflows/build-deploy-amc-stub.yaml
@@ -40,7 +40,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts && echo "$PWD/node_modules/.bin" >> $GITHUB_PATH
 
       - name: SAM validate
         run: sam validate


### PR DESCRIPTION
## What

AWS SAM strips `devDependencies` during its build process to optimise Lambda payload size. This behaviour consistently removes the `esbuild` compiler right before SAM attempts to bundle the code.

Standard AWS SAM workarounds fail because of this:
- `sam build --use-container` fails because the container's internal installation runs strictly in production mode, ignoring dev dependencies entirely.
- `sam build --build-in-source` fails because SAM runs a production prune directly in the host directory, actively deleting the locally installed compiler just before the bundle step executes.

By explicitly injecting the host's `./node_modules/.bin` directory into the GitHub Actions `$GITHUB_PATH`, we elevate the local compiler to the system level. When SAM isolates the build into a temporary scratch folder and wipes its local dev dependencies, it falls back to the runner's system path, finds the host's `esbuild` binary, and successfully compiles the Lambda artifact.

## How to review

1. Code Review


