### PR TITLE
BAU: fix amc dev deploy workflow

### DIFF
--- a/.github/workflows/dev-deploy-amc-stub.yaml
+++ b/.github/workflows/dev-deploy-amc-stub.yaml
@@ -45,7 +45,7 @@ jobs:
           node-version: '22.12.0'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts && echo "$PWD/node_modules/.bin" >> $GITHUB_PATH
 
       - name: CloudFormation lint
         run: |


### PR DESCRIPTION
## What

AWS SAM strips `devDependencies` during its build process to optimise Lambda payload size. This behavior consistently removes the `esbuild` compiler right before SAM attempts to bundle the code.

Standard AWS SAM workarounds fail because of this:
- `--use-container` fails because the container's internal installation runs strictly in production mode, ignoring dev dependencies entirely.
- `--build-in-source` fails because SAM runs a production prune directly in the host directory, actively deleting the locally installed compiler just before the bundle step executes.

By explicitly injecting the host's `./node_modules/.bin` directory into the GitHub Actions `$GITHUB_PATH`, we elevate the local compiler to the system level. When SAM isolates the build into a temporary scratch folder and wipes its local dev dependencies, it falls back to the runner's system path, finds the host's `esbuild` binary, and successfully compiles the Lambda artifact.

## How to review

1. Code Review


## Related Pull Requests
