### PR TITLE
Bau/update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: "/ipv-stub"
     open-pull-requests-limit: 10
@@ -43,3 +45,5 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 20" ]
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     target-branch: main
     schedule:
       interval: daily
@@ -41,6 +44,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 20" ]
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     target-branch: main
     schedule:
       interval: daily
@@ -57,6 +63,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 22" ]
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     target-branch: main
     schedule:
       interval: daily
@@ -73,6 +82,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         versions: [ "> 24" ]
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     target-branch: main
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,35 @@ updates:
       time: "03:00"
     cooldown:
       default-days: 7
+  - package-ecosystem: npm
+    directory: "/amc-stub"
+    open-pull-requests-limit: 10
+    groups:
+      npm-eslint-dependencies:
+        patterns:
+          - "*eslint*"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [ "> 22" ]
+    target-branch: main
+    schedule:
+      interval: daily
+      time: "03:00"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: npm
+    directory: "/notify-stub"
+    open-pull-requests-limit: 10
+    groups:
+      npm-eslint-dependencies:
+        patterns:
+          - "*eslint*"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [ "> 24" ]
+    target-branch: main
+    schedule:
+      interval: daily
+      time: "03:00"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Updates the dependabot config to:

* add cooldown period for individual projects
* specifically add config for the notify stub and amc stub
* Ignore patch updates for all to reduce noise
