### PR TITLE
Revert "BAU: Remove txma-audit-encoded header as a required header"

### DIFF
--- a/amc-stub/src/helpers/expected-headers-helper.ts
+++ b/amc-stub/src/helpers/expected-headers-helper.ts
@@ -5,6 +5,7 @@ import { truncate } from "./truncate-helper.ts";
 const REQUIRED_HEADERS = [
   "di-persistent-session-id",
   "client-session-id",
+  "txma-audit-encoded",
   "session-id",
   "x-forwarded-for",
   "user-language",

--- a/amc-stub/test/helpers/expected-headers-helper.test.ts
+++ b/amc-stub/test/helpers/expected-headers-helper.test.ts
@@ -60,7 +60,7 @@ describe("validateRequiredHeaders", () => {
 
     expect(result?.statusCode).to.eq(400);
     expect(result?.body).to.eq(
-      "Missing required headers: client-session-id, session-id, x-forwarded-for, user-language"
+      "Missing required headers: client-session-id, txma-audit-encoded, session-id, x-forwarded-for, user-language"
     );
   });
 
@@ -71,7 +71,7 @@ describe("validateRequiredHeaders", () => {
 
     expect(result?.statusCode).to.eq(400);
     expect(result?.body).to.eq(
-      "Missing required headers: di-persistent-session-id, client-session-id, session-id, x-forwarded-for, user-language"
+      "Missing required headers: di-persistent-session-id, client-session-id, txma-audit-encoded, session-id, x-forwarded-for, user-language"
     );
   });
 });


### PR DESCRIPTION
## What

This reverts commit 4dd1111e21d53d2f9aee113979f9b84f71375d43 as we have now got the txma-audit-encoded header on authdev envs as part of [ this PR](https://github.com/govuk-one-login/authentication-infrastructure/pull/132)

## How to review
 
1. Code review
2. Deploy to an authdev and check you can run a create passkey journey. Check you can correctly go to the stub and get to the passkey-created page

## Related Pull Requests
