### PR TITLE
AUT-5324: Assert presence of scope and redirect uri query params

### DIFF
--- a/amc-stub/scripts/encrypt-message-locally.ts
+++ b/amc-stub/scripts/encrypt-message-locally.ts
@@ -76,7 +76,7 @@ const createRequestJWT = async (scope: string) => {
   const now = Math.floor(Date.now() / 1000);
   const requestPayload = {
     iss: "https://signin.account.gov.uk",
-    client_id: "auth_amc",
+    client_id: "auth",
     aud: "https://manage.account.gov.uk/authorize",
     response_type: "code",
     redirect_uri: "https://signin.account.gov.uk/{callback_endpoint}",

--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -44,6 +44,14 @@ async function get(event: APIGatewayProxyEvent) {
     throw new CodedError(400, "Request query string parameter not found");
   }
 
+  if (!event.queryStringParameters["scope"]) {
+    throw new CodedError(400, "scope query string parameter not found");
+  }
+
+  if (!event.queryStringParameters["redirect_uri"]) {
+    throw new CodedError(400, "redirect_uri query string parameter not found");
+  }
+
   const amcPrivateEncryptionKey = process.env.AMC_PRIVATE_ENCRYPTION_KEY;
   if (!amcPrivateEncryptionKey) {
     throw new CodedError(500, "Private encryption key not found");

--- a/amc-stub/src/helpers/jwt-validator.ts
+++ b/amc-stub/src/helpers/jwt-validator.ts
@@ -137,23 +137,17 @@ async function validateAuthorizationRequest(
     return error;
   }
 
-  const environment = process.env.ENVIRONMENT || "local";
-  let expectedIssuer: string;
-  if (environment === "local") {
-    expectedIssuer = "https://signin.account.gov.uk";
-  } else if (environment.startsWith("authdev")) {
-    expectedIssuer = `https://signin.${environment}.dev.account.gov.uk`;
-  } else {
-    expectedIssuer = `https://signin.${environment}.account.gov.uk`;
-  }
-
-  if (verifiedJWT.payload.iss !== expectedIssuer) {
+  if (verifiedJWT.payload.iss !== "auth") {
     const error = "The authorization request JWT payload issuer is invalid";
-    logger.error(error, { payload: verifiedJWT.payload, expectedIssuer });
+    logger.error(error, {
+      payload: verifiedJWT.payload,
+      expectedIssuer: "auth",
+    });
     return error;
   }
 
   let expectedAudience: string;
+  const environment = process.env.ENVIRONMENT || "local";
   if (environment === "local") {
     expectedAudience = "https://manage.account.gov.uk/authorize";
   } else if (environment.startsWith("authdev")) {
@@ -182,8 +176,8 @@ async function validateAuthorizationRequest(
     return error;
   }
 
-  if (verifiedJWT.payload.client_id !== "auth_amc") {
-    const error = "The authorization request JWT client ID must be 'auth_amc'";
+  if (verifiedJWT.payload.client_id !== "auth") {
+    const error = "The authorization request JWT client ID must be 'auth'";
     logger.error(error, { payload: verifiedJWT.payload });
     return error;
   }

--- a/amc-stub/test/endpoints/amc-authorize.test.ts
+++ b/amc-stub/test/endpoints/amc-authorize.test.ts
@@ -60,6 +60,8 @@ describe("AMC Authorize Stub Test", () => {
 
         const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
           request: encryptedJWT,
+          scope: scope,
+          redirect_uri: "https://example.com/callback",
         });
 
         const result = await handler(event);
@@ -99,6 +101,41 @@ describe("AMC Authorize Stub Test", () => {
         expect((error as { code: number }).code).to.eq(400);
         expect((error as Error).message).to.eq(
           "Request query string parameter not found"
+        );
+      }
+    });
+
+    it("should return 400 when scope parameter is missing", async () => {
+      const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
+        request: "some-encrypted-jwt",
+      });
+
+      try {
+        await handler(event);
+        expect.fail("Should have thrown an error");
+      } catch (error: unknown) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as { code: number }).code).to.eq(400);
+        expect((error as Error).message).to.eq(
+          "scope query string parameter not found"
+        );
+      }
+    });
+
+    it("should return 400 when redirect_uri parameter is missing", async () => {
+      const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
+        request: "some-encrypted-jwt",
+        scope: "passkey-create",
+      });
+
+      try {
+        await handler(event);
+        expect.fail("Should have thrown an error");
+      } catch (error: unknown) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as { code: number }).code).to.eq(400);
+        expect((error as Error).message).to.eq(
+          "redirect_uri query string parameter not found"
         );
       }
     });

--- a/amc-stub/test/helpers/jwt-validator.test.ts
+++ b/amc-stub/test/helpers/jwt-validator.test.ts
@@ -80,7 +80,7 @@ describe("jwt validator tests", () => {
         scope
       );
       expect(payload.account_management_api_access_token!.iss).to.equal(
-        TEST_CONSTANTS.ISSUER
+        TEST_CONSTANTS.ACCESS_TOKEN_ISSUER
       );
       expect(payload.account_management_api_access_token!.aud).to.equal(
         TEST_CONSTANTS.AUTH_AUDIENCE
@@ -321,7 +321,7 @@ describe("jwt validator tests", () => {
         .build();
 
       expect(await validateCompositeJWT(JWT)).to.equal(
-        "The authorization request JWT client ID must be 'auth_amc'"
+        "The authorization request JWT client ID must be 'auth'"
       );
     });
   });

--- a/amc-stub/test/test-helpers.ts
+++ b/amc-stub/test/test-helpers.ts
@@ -15,8 +15,9 @@ const textEncoder = new TextEncoder();
 
 export const TEST_CONSTANTS = {
   SUBJECT: "urn:fdc:gov.uk:2022:7KWZkhSXFYrmMP_SRsZJU-0Z4AQ",
-  CLIENT_ID: "auth_amc",
-  ISSUER: "https://signin.account.gov.uk",
+  CLIENT_ID: "auth",
+  ISSUER: "auth",
+  ACCESS_TOKEN_ISSUER: "https://signin.account.gov.uk",
   AMC_AUDIENCE: "https://manage.account.gov.uk/authorize",
   AUTH_AUDIENCE: "https://manage.account.gov.uk",
   REDIRECT_URI: 'https://signin.account.gov.uk/amc/callback/authorize"',
@@ -66,7 +67,7 @@ export const createTestEvent = (
 export class AccessTokenBuilder {
   private sub: string | undefined = TEST_CONSTANTS.SUBJECT;
   private scope: string | undefined = AMCScopes.ACCOUNT_DELETE;
-  private iss: string | undefined = TEST_CONSTANTS.ISSUER;
+  private iss: string | undefined = TEST_CONSTANTS.ACCESS_TOKEN_ISSUER;
   private aud: string | undefined = TEST_CONSTANTS.AUTH_AUDIENCE;
   private clientId: string | undefined = TEST_CONSTANTS.CLIENT_ID;
   private jti: string | undefined = TEST_CONSTANTS.ACCESS_TOKEN_JTI;


### PR DESCRIPTION
## What

- Staging integration with AMC failed as we were missing these params.
- Params must satisfy schema defined here: https://github.com/govuk-one-login/account-components/blob/3e44199854f66ea013ff266b2163f30bc59ec5be/solutions/frontend/src/handlers/authorize/utils/getQueryParams.ts#L10-L32
## How to review

1. Code Review

