### PR TITLE
AUT-5324: Assert kid is sent in JAR header

### DIFF
--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -72,6 +72,10 @@ async function get(event: APIGatewayProxyEvent) {
     throw new CodedError(500, "compactDecrypt returned undefined values");
   }
 
+  if (!protectedHeader.kid) {
+    throw new CodedError(400, "JAR header is missing kid");
+  }
+
   const textDecoder = new TextDecoder();
   const encodedJwt = textDecoder.decode(plaintext);
 

--- a/amc-stub/test/endpoints/amc-authorize.test.ts
+++ b/amc-stub/test/endpoints/amc-authorize.test.ts
@@ -55,7 +55,11 @@ describe("AMC Authorize Stub Test", () => {
         const encryptedJWT = await new CompactEncrypt(
           textEncoder.encode(compositeJWT)
         )
-          .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+          .setProtectedHeader({
+            alg: "RSA-OAEP-256",
+            enc: "A256GCM",
+            kid: "test-key-id",
+          })
           .encrypt(publicKey);
 
         const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
@@ -87,6 +91,41 @@ describe("AMC Authorize Stub Test", () => {
         expect((error as Error).message).to.eq(
           "Query string parameters are null"
         );
+      }
+    });
+
+    it("should return 400 when kid is missing from JWE header", async () => {
+      const accessToken = await new AccessTokenBuilder(
+        keys.authPrivateSigningKeyAuthAudience
+      ).build();
+      const compositeJWT = await new CompositeJWTBuilder(
+        keys.authPrivateSigningKeyAMCAudience,
+        accessToken
+      ).build();
+
+      const publicKey = await importSPKI(
+        keys.amcPublicEncryptionKey,
+        "RSA-OAEP-256"
+      );
+      const encryptedJWT = await new CompactEncrypt(
+        textEncoder.encode(compositeJWT)
+      )
+        .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM" })
+        .encrypt(publicKey);
+
+      const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
+        request: encryptedJWT,
+        scope: "account-delete",
+        redirect_uri: "https://example.com/callback",
+      });
+
+      try {
+        await handler(event);
+        expect.fail("Should have thrown an error");
+      } catch (error: unknown) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as { code: number }).code).to.eq(400);
+        expect((error as Error).message).to.eq("JAR header is missing kid");
       }
     });
 


### PR DESCRIPTION
## What

AMC does this, so the stub should as well

## How to review



1. Code Review
2. Test alongside authentication-api changes

## Related Pull Requests
https://github.com/govuk-one-login/authentication-api/pull/8260