### PR TITLE
BAU: fix AMC stub access token scope validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ logs/
 # Contract Tests
 /*/src/test/pact/
 node_modules
+dist/
 .infracost
 
 *.pem

--- a/amc-stub/src/helpers/jwt-validator.ts
+++ b/amc-stub/src/helpers/jwt-validator.ts
@@ -7,7 +7,13 @@ import {
   JwksConfig,
   VerifiedAuthorizationRequestPayload,
 } from "../types/types.ts";
-import { AccessTokenApi, AMCScopes } from "../types/enums.ts";
+import {
+  AccessTokenApi,
+  AccountDataAccessTokenScopes,
+  AccessTokenFieldName,
+  AMCScopes,
+  SFADAccessTokenScopes,
+} from "../types/enums.ts";
 import { logger } from "../../logger.ts";
 
 const getAccessTokenConfig = () =>
@@ -44,11 +50,15 @@ async function validateAccessToken(
     publicSigningKeyAuthAudience
   );
 
-  const validScopes = Object.values(AMCScopes);
+  const scopesByTokenType: Record<AccessTokenApi, string[]> = {
+    [AccessTokenApi.ACCOUNT_DATA]: Object.values(AccountDataAccessTokenScopes),
+    [AccessTokenApi.ACCOUNT_MANAGEMENT]: Object.values(SFADAccessTokenScopes),
+  };
+
+  const validScopes = scopesByTokenType[tokenType];
+
   if (
-    !verifiedJWT.payload.scope
-      ?.split(" ")
-      .every((s) => validScopes.includes(s as AMCScopes))
+    !verifiedJWT.payload.scope?.split(" ").every((s) => validScopes.includes(s))
   ) {
     const error = "The access token payload contains invalid scopes";
     logger.error(error, { payload: verifiedJWT.payload });
@@ -211,15 +221,28 @@ export async function validateCompositeJWT(
     return "The authorization request JWT payload must contain only one access token";
   }
 
+  const expectedTokenField =
+    authorizationRequestPayload.scope === AMCScopes.ACCOUNT_DELETE
+      ? AccessTokenFieldName.ACCOUNT_MANAGEMENT
+      : AccessTokenFieldName.ACCOUNT_DATA;
+
   const accessToken =
     account_management_api_access_token ?? account_data_api_access_token;
-  const tokenType: AccessTokenApiType = account_management_api_access_token
-    ? AccessTokenApi.ACCOUNT_MANAGEMENT
-    : AccessTokenApi.ACCOUNT_DATA;
+  const actualTokenField = account_management_api_access_token
+    ? AccessTokenFieldName.ACCOUNT_MANAGEMENT
+    : AccessTokenFieldName.ACCOUNT_DATA;
 
   if (!accessToken) {
     return "The authorization request JWT payload must contain an access token";
   }
+
+  if (actualTokenField !== expectedTokenField) {
+    return `The access token field does not match the outer scope. Expected ${expectedTokenField} for scope ${authorizationRequestPayload.scope}`;
+  }
+
+  const tokenType: AccessTokenApiType = account_management_api_access_token
+    ? AccessTokenApi.ACCOUNT_MANAGEMENT
+    : AccessTokenApi.ACCOUNT_DATA;
 
   const accessTokenResultOrError = await validateAccessToken(
     accessToken,
@@ -232,14 +255,10 @@ export async function validateCompositeJWT(
 
   const { payload: accessTokenPayload } = accessTokenResultOrError;
 
-  const accessTokenFieldName = account_management_api_access_token
-    ? "account_management_api_access_token"
-    : "account_data_api_access_token";
-
   return {
     payload: {
       ...authorizationRequestPayload,
-      [accessTokenFieldName]: accessTokenPayload,
+      [actualTokenField]: accessTokenPayload,
     } as VerifiedAuthorizationRequestPayload,
   };
 }

--- a/amc-stub/src/types/enums.ts
+++ b/amc-stub/src/types/enums.ts
@@ -22,7 +22,23 @@ export enum AMCScopes {
   PASSKEY_CREATE = "passkey-create",
 }
 
+export enum AccountDataAccessTokenScopes {
+  PASSKEY_CREATE = "passkey-create",
+  PASSKEY_RETRIEVE = "passkey-retrieve",
+  PASSKEY_UPDATE = "passkey-update",
+  PASSKEY_DELETE = "passkey-delete",
+}
+
+export enum SFADAccessTokenScopes {
+  ACCOUNT_DELETE = "account-delete",
+}
+
 export enum AccessTokenApi {
   ACCOUNT_MANAGEMENT = "account-management",
   ACCOUNT_DATA = "account-data",
+}
+
+export enum AccessTokenFieldName {
+  ACCOUNT_MANAGEMENT = "account_management_api_access_token",
+  ACCOUNT_DATA = "account_data_api_access_token",
 }

--- a/amc-stub/test/endpoints/amc-authorize.test.ts
+++ b/amc-stub/test/endpoints/amc-authorize.test.ts
@@ -6,7 +6,12 @@ import {
   CompositeJWTBuilder,
   createTestEvent,
 } from "../test-helpers.js";
-import { AMCScopes, HttpMethod } from "../../src/types/enums.ts";
+import {
+  AccountDataAccessTokenScopes,
+  AMCScopes,
+  HttpMethod,
+  SFADAccessTokenScopes,
+} from "../../src/types/enums.ts";
 import keys from "../../data/keys.json" with { type: "json" };
 import { CompactEncrypt, importSPKI } from "jose";
 import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
@@ -34,47 +39,15 @@ describe("AMC Authorize Stub Test", () => {
       process.env.ENVIRONMENT = "local";
     });
 
-    [AMCScopes.ACCOUNT_DELETE, AMCScopes.PASSKEY_CREATE].forEach((scope) => {
+    [AMCScopes.PASSKEY_CREATE, AMCScopes.ACCOUNT_DELETE].forEach((scope) => {
       it(`should return 200 with HTML for valid GET request with scope ${scope}`, async () => {
-        const accessToken = await new AccessTokenBuilder(
-          keys.authPrivateSigningKeyAuthAudience
-        )
-          .withScope(scope)
-          .build();
-        const compositeJWT = await new CompositeJWTBuilder(
-          keys.authPrivateSigningKeyAMCAudience,
-          accessToken
-        )
-          .withScope(scope)
-          .build();
-
-        const publicKey = await importSPKI(
-          keys.amcPublicEncryptionKey,
-          "RSA-OAEP-256"
-        );
-        const encryptedJWT = await new CompactEncrypt(
-          textEncoder.encode(compositeJWT)
-        )
-          .setProtectedHeader({
-            alg: "RSA-OAEP-256",
-            enc: "A256GCM",
-            kid: "test-key-id",
-          })
-          .encrypt(publicKey);
-
-        const event = createTestEvent(HttpMethod.GET, "/authorize", null, {
-          request: encryptedJWT,
-          scope: scope,
-          redirect_uri: "https://example.com/callback",
-        });
+        const event = await createSuccessfulTestEventForAMCScope(scope);
 
         const result = await handler(event);
 
         expect(result.statusCode).to.eq(200);
         expect(result.headers?.["Content-Type"]).to.eq("text/html");
-        expect(result.body).to.include(
-          `AMC stub (${scope.split("-").join(" ")})`
-        );
+        expect(result.body).to.include(`AMC stub (${scope.replace("-", " ")})`);
         expect(result.body).to.include("Decrypted JAR header");
       });
     });
@@ -100,7 +73,8 @@ describe("AMC Authorize Stub Test", () => {
       ).build();
       const compositeJWT = await new CompositeJWTBuilder(
         keys.authPrivateSigningKeyAMCAudience,
-        accessToken
+        accessToken,
+        undefined
       ).build();
 
       const publicKey = await importSPKI(
@@ -315,3 +289,50 @@ describe("AMC Authorize Stub Test", () => {
     });
   });
 });
+
+async function createSuccessfulTestEventForAMCScope(amcScope: AMCScopes) {
+  const accessToken = await new AccessTokenBuilder(
+    keys.authPrivateSigningKeyAuthAudience
+  )
+    .withScope(
+      amcScope === AMCScopes.ACCOUNT_DELETE
+        ? Object.values(SFADAccessTokenScopes)
+        : Object.values(AccountDataAccessTokenScopes)
+    )
+    .build();
+
+  const builder =
+    amcScope === AMCScopes.ACCOUNT_DELETE
+      ? new CompositeJWTBuilder(
+          keys.authPrivateSigningKeyAMCAudience,
+          accessToken,
+          undefined
+        )
+      : new CompositeJWTBuilder(
+          keys.authPrivateSigningKeyAMCAudience,
+          undefined,
+          accessToken
+        );
+
+  const compositeJWT = await builder.withScope(amcScope).build();
+
+  const publicKey = await importSPKI(
+    keys.amcPublicEncryptionKey,
+    "RSA-OAEP-256"
+  );
+  const encryptedJWT = await new CompactEncrypt(
+    textEncoder.encode(compositeJWT)
+  )
+    .setProtectedHeader({
+      alg: "RSA-OAEP-256",
+      enc: "A256GCM",
+      kid: "test-key-id",
+    })
+    .encrypt(publicKey);
+
+  return createTestEvent(HttpMethod.GET, "/authorize", null, {
+    request: encryptedJWT,
+    scope: amcScope,
+    redirect_uri: "https://example.com/callback",
+  });
+}

--- a/amc-stub/test/helpers/jwt-validator.test.ts
+++ b/amc-stub/test/helpers/jwt-validator.test.ts
@@ -8,7 +8,11 @@ import {
   TEST_CONSTANTS,
 } from "../test-helpers.ts";
 import { validateCompositeJWT } from "../../src/helpers/jwt-validator.ts";
-import { AMCScopes } from "../../src/types/enums.ts";
+import {
+  AccountDataAccessTokenScopes,
+  AMCScopes,
+  SFADAccessTokenScopes,
+} from "../../src/types/enums.ts";
 import { VerifiedAuthorizationRequestPayload } from "../../src/types/types.ts";
 import { expect } from "chai";
 
@@ -26,75 +30,143 @@ describe("jwt validator tests", () => {
     delete process.env.ENVIRONMENT;
   });
 
-  [AMCScopes.ACCOUNT_DELETE, AMCScopes.PASSKEY_CREATE].forEach((scope) => {
-    it(`should validate the composite JWT for scope ${scope}`, async () => {
-      const JWT = await new CompositeJWTBuilder(
-        keys.authPrivateSigningKeyAMCAudience,
-        await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
-          .withScope(scope)
-          .build()
-      )
-        .withScope(scope)
-        .build();
+  it(`should validate the composite JWT for scope account-delete`, async () => {
+    const allSFADScopes = Object.values(SFADAccessTokenScopes);
+    const JWT = await new CompositeJWTBuilder(
+      keys.authPrivateSigningKeyAMCAudience,
+      await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
+        .withScope(allSFADScopes)
+        .build(),
+      undefined
+    )
+      .withScope(AMCScopes.ACCOUNT_DELETE)
+      .build();
 
-      const result = await validateCompositeJWT(JWT);
-      expect(result).to.not.be.a("string");
-      const { payload } = result as {
-        payload: VerifiedAuthorizationRequestPayload;
-      };
+    const result = await validateCompositeJWT(JWT);
+    expect(result).to.not.be.a("string");
+    const { payload } = result as {
+      payload: VerifiedAuthorizationRequestPayload;
+    };
 
-      const now = Math.floor(Date.now() / 1000);
+    const now = Math.floor(Date.now() / 1000);
 
-      // Authorization Request JWT assertions
-      expect(payload.iss).to.equal(TEST_CONSTANTS.ISSUER);
-      expect(payload.client_id).to.equal(TEST_CONSTANTS.CLIENT_ID);
-      expect(payload.aud).to.equal(TEST_CONSTANTS.AMC_AUDIENCE);
-      expect(payload.response_type).to.equal(TEST_CONSTANTS.RESPONSE_TYPE);
-      expect(payload.redirect_uri).to.equal(TEST_CONSTANTS.REDIRECT_URI);
-      expect(payload.scope).to.equal(scope);
-      expect(payload.state).to.equal(TEST_CONSTANTS.STATE);
-      expect(payload.jti).to.equal(TEST_CONSTANTS.AUTHORIZATION_REQUEST_JTI);
-      expect(payload.iat).to.be.closeTo(now, 10);
-      expect(payload.nbf).to.be.closeTo(now, 10);
-      expect(payload.exp).to.equal(payload.iat! + 300);
-      expect(payload.sub).to.equal(TEST_CONSTANTS.SUBJECT);
-      expect(payload.email).to.equal(TEST_CONSTANTS.EMAIL);
-      expect(payload.public_sub).to.equal(TEST_CONSTANTS.PUBLIC_SUBJECT);
+    // Authorization Request JWT assertions
+    expect(payload.iss).to.equal(TEST_CONSTANTS.ISSUER);
+    expect(payload.client_id).to.equal(TEST_CONSTANTS.CLIENT_ID);
+    expect(payload.aud).to.equal(TEST_CONSTANTS.AMC_AUDIENCE);
+    expect(payload.response_type).to.equal(TEST_CONSTANTS.RESPONSE_TYPE);
+    expect(payload.redirect_uri).to.equal(TEST_CONSTANTS.REDIRECT_URI);
+    expect(payload.scope).to.equal(AMCScopes.ACCOUNT_DELETE);
+    expect(payload.state).to.equal(TEST_CONSTANTS.STATE);
+    expect(payload.jti).to.equal(TEST_CONSTANTS.AUTHORIZATION_REQUEST_JTI);
+    expect(payload.iat).to.be.closeTo(now, 10);
+    expect(payload.nbf).to.be.closeTo(now, 10);
+    expect(payload.exp).to.equal(payload.iat! + 300);
+    expect(payload.sub).to.equal(TEST_CONSTANTS.SUBJECT);
+    expect(payload.email).to.equal(TEST_CONSTANTS.EMAIL);
+    expect(payload.public_sub).to.equal(TEST_CONSTANTS.PUBLIC_SUBJECT);
 
-      // Access Token JWT assertions
-      expect(payload.account_management_api_access_token!.sub).to.equal(
-        TEST_CONSTANTS.SUBJECT
-      );
-      expect(payload.account_management_api_access_token!.iat).to.be.closeTo(
-        now,
-        10
-      );
-      expect(payload.account_management_api_access_token!.nbf).to.be.closeTo(
-        now,
-        10
-      );
-      expect(payload.account_management_api_access_token!.exp).to.equal(
-        payload.iat! + 3600
-      );
-      expect(payload.account_management_api_access_token!.scope).to.equal(
-        scope
-      );
-      expect(payload.account_management_api_access_token!.iss).to.equal(
-        TEST_CONSTANTS.ACCESS_TOKEN_ISSUER
-      );
-      expect(payload.account_management_api_access_token!.aud).to.equal(
-        TEST_CONSTANTS.AUTH_AUDIENCE
-      );
-      expect(payload.account_management_api_access_token!.client_id).to.equal(
-        TEST_CONSTANTS.CLIENT_ID
-      );
-      expect(payload.account_management_api_access_token!.sid).to.equal(
-        TEST_CONSTANTS.SESSION_ID
-      );
-      expect(payload.account_management_api_access_token!.jti).to.equal(
-        TEST_CONSTANTS.ACCESS_TOKEN_JTI
-      );
-    });
+    // Access Token JWT assertions
+    expect(payload.account_management_api_access_token!.sub).to.equal(
+      TEST_CONSTANTS.SUBJECT
+    );
+    expect(payload.account_management_api_access_token!.iat).to.be.closeTo(
+      now,
+      10
+    );
+    expect(payload.account_management_api_access_token!.nbf).to.be.closeTo(
+      now,
+      10
+    );
+    expect(payload.account_management_api_access_token!.exp).to.equal(
+      payload.iat! + 3600
+    );
+    expect(payload.account_management_api_access_token!.scope).to.equal(
+      allSFADScopes.join(" ")
+    );
+    expect(payload.account_management_api_access_token!.iss).to.equal(
+      TEST_CONSTANTS.ACCESS_TOKEN_ISSUER
+    );
+    expect(payload.account_management_api_access_token!.aud).to.equal(
+      TEST_CONSTANTS.AUTH_AUDIENCE
+    );
+    expect(payload.account_management_api_access_token!.client_id).to.equal(
+      TEST_CONSTANTS.CLIENT_ID
+    );
+    expect(payload.account_management_api_access_token!.sid).to.equal(
+      TEST_CONSTANTS.SESSION_ID
+    );
+    expect(payload.account_management_api_access_token!.jti).to.equal(
+      TEST_CONSTANTS.ACCESS_TOKEN_JTI
+    );
+  });
+
+  it(`should validate the composite JWT for scope passkey-create`, async () => {
+    const allAccountDataScopes = Object.values(AccountDataAccessTokenScopes);
+    const accessToken = await new AccessTokenBuilder(
+      keys.authPrivateSigningKeyAuthAudience
+    )
+      .withScope(allAccountDataScopes)
+      .build();
+    const JWT = await new CompositeJWTBuilder(
+      keys.authPrivateSigningKeyAMCAudience,
+      undefined,
+      accessToken
+    )
+      .withScope(AMCScopes.PASSKEY_CREATE)
+      .build();
+
+    const result = await validateCompositeJWT(JWT);
+    expect(result).to.not.be.a("string");
+    const { payload } = result as {
+      payload: VerifiedAuthorizationRequestPayload;
+    };
+
+    const now = Math.floor(Date.now() / 1000);
+
+    // Authorization Request JWT assertions
+    expect(payload.iss).to.equal(TEST_CONSTANTS.ISSUER);
+    expect(payload.client_id).to.equal(TEST_CONSTANTS.CLIENT_ID);
+    expect(payload.aud).to.equal(TEST_CONSTANTS.AMC_AUDIENCE);
+    expect(payload.response_type).to.equal(TEST_CONSTANTS.RESPONSE_TYPE);
+    expect(payload.redirect_uri).to.equal(TEST_CONSTANTS.REDIRECT_URI);
+    expect(payload.scope).to.equal(AMCScopes.PASSKEY_CREATE);
+    expect(payload.state).to.equal(TEST_CONSTANTS.STATE);
+    expect(payload.jti).to.equal(TEST_CONSTANTS.AUTHORIZATION_REQUEST_JTI);
+    expect(payload.iat).to.be.closeTo(now, 10);
+    expect(payload.nbf).to.be.closeTo(now, 10);
+    expect(payload.exp).to.equal(payload.iat! + 300);
+    expect(payload.sub).to.equal(TEST_CONSTANTS.SUBJECT);
+    expect(payload.email).to.equal(TEST_CONSTANTS.EMAIL);
+    expect(payload.public_sub).to.equal(TEST_CONSTANTS.PUBLIC_SUBJECT);
+
+    // Access Token JWT assertions
+    expect(payload.account_data_api_access_token!.sub).to.equal(
+      TEST_CONSTANTS.SUBJECT
+    );
+    expect(payload.account_data_api_access_token!.iat).to.be.closeTo(now, 10);
+    expect(payload.account_data_api_access_token!.nbf).to.be.closeTo(now, 10);
+    expect(payload.account_data_api_access_token!.exp).to.equal(
+      payload.iat! + 3600
+    );
+    expect(payload.account_data_api_access_token!.scope).to.equal(
+      allAccountDataScopes.join(" ")
+    );
+    expect(payload.account_data_api_access_token!.iss).to.equal(
+      TEST_CONSTANTS.ACCESS_TOKEN_ISSUER
+    );
+    expect(payload.account_data_api_access_token!.aud).to.equal(
+      TEST_CONSTANTS.AUTH_AUDIENCE
+    );
+    expect(payload.account_data_api_access_token!.client_id).to.equal(
+      TEST_CONSTANTS.CLIENT_ID
+    );
+    expect(payload.account_data_api_access_token!.sid).to.equal(
+      TEST_CONSTANTS.SESSION_ID
+    );
+    expect(payload.account_data_api_access_token!.jti).to.equal(
+      TEST_CONSTANTS.ACCESS_TOKEN_JTI
+    );
   });
 
   // ====================================
@@ -105,14 +177,15 @@ describe("jwt validator tests", () => {
     "INVALID_SCOPE",
     undefined,
     "",
-    `${AMCScopes.ACCOUNT_DELETE} EXTRA_SCOPE`,
+    `${SFADAccessTokenScopes.ACCOUNT_DELETE} EXTRA_SCOPE`,
   ].forEach((scope) => {
     it(`should return an error string if the access token scope is ${scope}`, async () => {
       const JWT = await new CompositeJWTBuilder(
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
           .withScope(scope)
-          .build()
+          .build(),
+        undefined
       ).build();
 
       expect(await validateCompositeJWT(JWT)).to.equal(
@@ -127,7 +200,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
           .withIssuer(issuer)
-          .build()
+          .build(),
+        undefined
       ).build();
 
       expect(await validateCompositeJWT(JWT)).to.equal(
@@ -142,7 +216,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
           .withAudience(audience)
-          .build()
+          .build(),
+        undefined
       ).build();
 
       expect(await validateCompositeJWT(JWT)).to.equal(
@@ -156,7 +231,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
         .withSubject(undefined)
-        .build()
+        .build(),
+      undefined
     ).build();
 
     expect(await validateCompositeJWT(JWT)).to.equal(
@@ -169,7 +245,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
         .withClientId(undefined)
-        .build()
+        .build(),
+      undefined
     ).build();
 
     expect(await validateCompositeJWT(JWT)).to.equal(
@@ -182,7 +259,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(keys.authPrivateSigningKeyAuthAudience)
         .withJti(undefined)
-        .build()
+        .build(),
+      undefined
     ).build();
 
     expect(await validateCompositeJWT(JWT)).to.equal(
@@ -193,10 +271,9 @@ describe("jwt validator tests", () => {
   it("should return an error string if no access token is present", async () => {
     const JWT = await new CompositeJWTBuilder(
       keys.authPrivateSigningKeyAMCAudience,
-      ""
-    )
-      .withAccountManagementApiAccessToken(undefined)
-      .build();
+      undefined,
+      undefined
+    ).build();
 
     expect(await validateCompositeJWT(JWT)).to.equal(
       "The authorization request JWT payload must contain an access token"
@@ -209,13 +286,48 @@ describe("jwt validator tests", () => {
     ).build();
     const JWT = await new CompositeJWTBuilder(
       keys.authPrivateSigningKeyAMCAudience,
+      accessToken,
       accessToken
-    )
-      .withAccountDataApiAccessToken(accessToken)
-      .build();
+    ).build();
 
     expect(await validateCompositeJWT(JWT)).to.equal(
       "The authorization request JWT payload must contain only one access token"
+    );
+  });
+
+  it("should return an error when outer scope is account-delete but access token is in account_data_api_access_token", async () => {
+    const accessToken = await new AccessTokenBuilder(
+      keys.authPrivateSigningKeyAuthAudience
+    ).build();
+    const JWT = await new CompositeJWTBuilder(
+      keys.authPrivateSigningKeyAMCAudience,
+      undefined,
+      accessToken
+    )
+      .withScope(AMCScopes.ACCOUNT_DELETE)
+      .build();
+
+    expect(await validateCompositeJWT(JWT)).to.equal(
+      "The access token field does not match the outer scope. Expected account_management_api_access_token for scope account-delete"
+    );
+  });
+
+  it("should return an error when outer scope is passkey-create but access token is in account_management_api_access_token", async () => {
+    const accessToken = await new AccessTokenBuilder(
+      keys.authPrivateSigningKeyAuthAudience
+    )
+      .withScope(AccountDataAccessTokenScopes.PASSKEY_CREATE)
+      .build();
+    const JWT = await new CompositeJWTBuilder(
+      keys.authPrivateSigningKeyAMCAudience,
+      accessToken,
+      undefined
+    )
+      .withScope(AMCScopes.PASSKEY_CREATE)
+      .build();
+
+    expect(await validateCompositeJWT(JWT)).to.equal(
+      "The access token field does not match the outer scope. Expected account_data_api_access_token for scope passkey-create"
     );
   });
 
@@ -234,7 +346,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(
           keys.authPrivateSigningKeyAuthAudience
-        ).build()
+        ).build(),
+        undefined
       )
         .withScope(scope)
         .build();
@@ -251,7 +364,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(
           keys.authPrivateSigningKeyAuthAudience
-        ).build()
+        ).build(),
+        undefined
       )
         .withIssuer(issuer)
         .build();
@@ -268,7 +382,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(
           keys.authPrivateSigningKeyAuthAudience
-        ).build()
+        ).build(),
+        undefined
       )
         .withAudience(audience)
         .build();
@@ -284,7 +399,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(
         keys.authPrivateSigningKeyAuthAudience
-      ).build()
+      ).build(),
+      undefined
     )
       .withSubject(undefined)
       .build();
@@ -299,7 +415,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(
         keys.authPrivateSigningKeyAuthAudience
-      ).build()
+      ).build(),
+      undefined
     )
       .withPublicSubject(undefined)
       .build();
@@ -315,7 +432,8 @@ describe("jwt validator tests", () => {
         keys.authPrivateSigningKeyAMCAudience,
         await new AccessTokenBuilder(
           keys.authPrivateSigningKeyAuthAudience
-        ).build()
+        ).build(),
+        undefined
       )
         .withClientId(clientId)
         .build();
@@ -331,7 +449,8 @@ describe("jwt validator tests", () => {
       keys.authPrivateSigningKeyAMCAudience,
       await new AccessTokenBuilder(
         keys.authPrivateSigningKeyAuthAudience
-      ).build()
+      ).build(),
+      undefined
     )
       .withJti(undefined)
       .build();

--- a/amc-stub/test/test-helpers.ts
+++ b/amc-stub/test/test-helpers.ts
@@ -3,7 +3,12 @@ import {
   APIGatewayEventRequestContext,
   APIGatewayProxyEventHeaders,
 } from "aws-lambda";
-import { AMCScopes, HttpMethod, JoseAlgorithms } from "../src/types/enums.ts";
+import {
+  AMCScopes,
+  HttpMethod,
+  JoseAlgorithms,
+  SFADAccessTokenScopes,
+} from "../src/types/enums.ts";
 import {
   CompactJWSHeaderParameters,
   CompactSign,
@@ -66,7 +71,7 @@ export const createTestEvent = (
 
 export class AccessTokenBuilder {
   private sub: string | undefined = TEST_CONSTANTS.SUBJECT;
-  private scope: string | undefined = AMCScopes.ACCOUNT_DELETE;
+  private scope: string | undefined = SFADAccessTokenScopes.ACCOUNT_DELETE;
   private iss: string | undefined = TEST_CONSTANTS.ACCESS_TOKEN_ISSUER;
   private aud: string | undefined = TEST_CONSTANTS.AUTH_AUDIENCE;
   private clientId: string | undefined = TEST_CONSTANTS.CLIENT_ID;
@@ -158,11 +163,11 @@ export class CompositeJWTBuilder {
   private readonly email = TEST_CONSTANTS.EMAIL;
   private publicSub: string | undefined = TEST_CONSTANTS.PUBLIC_SUBJECT;
   private readonly expiresIn = 300;
-  private accountDataApiAccessToken: string | undefined = undefined;
 
   constructor(
     private readonly signingKey: string,
-    private accountManagementApiAccessToken: string | undefined
+    private readonly accountManagementApiAccessToken: string | undefined,
+    private readonly accountDataApiAccessToken: string | undefined
   ) {}
 
   async build() {
@@ -208,16 +213,6 @@ export class CompositeJWTBuilder {
 
   withSubject(sub: string | undefined) {
     this.sub = sub;
-    return this;
-  }
-
-  withAccountManagementApiAccessToken(token: string | undefined) {
-    this.accountManagementApiAccessToken = token;
-    return this;
-  }
-
-  withAccountDataApiAccessToken(token: string) {
-    this.accountDataApiAccessToken = token;
     return this;
   }
 


### PR DESCRIPTION
## What

- AMC access token scopes are now different to AMCScopes. AMCScopes are used for the outer JWT, and are a single value representing the journey.
- The access token, however, requires more granularly defined scopes for steps _within_ the AMC journey, e.g. all of the PASSKEY_* scopes required to trigger specific account data API endpoints successfully
- Have added these more granular scopes for both SFAD and account data
- 
## How to review

1. Code Review
2. See AMC tests are now working in dev acceptance tests



