### PR TITLE
BAU: Override qs to 6.15.2 to fix CVE-2026-8723

### DIFF
--- a/orchestration-stub/package-lock.json
+++ b/orchestration-stub/package-lock.json
@@ -8056,9 +8056,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/orchestration-stub/package.json
+++ b/orchestration-stub/package.json
@@ -35,6 +35,9 @@
   "license": "MIT",
   "main": "index.js",
   "name": "orch-stub",
+  "overrides": {
+    "qs": ">=6.15.2"
+  },
   "scripts": {
     "build": "esbuild src/server.ts --bundle --minify --sourcemap --platform=node --outdir=build",
     "compile": "tsc",


### PR DESCRIPTION
## What

- CVE-2026-8723: prototype pollution in qs query string parser. Adding override in orchestration-stub to constrain transitive qs dependency to >=6.15.2 where the fix was released.

## How to review

1. Code Review