### PR TITLE
BAU: Override uuid to 11.1.1 to fix CVE-2026-41907

### DIFF
--- a/orchestration-stub/package-lock.json
+++ b/orchestration-stub/package-lock.json
@@ -6807,16 +6807,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-junit/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/jest-leak-detector": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
@@ -9168,6 +9158,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/orchestration-stub/package.json
+++ b/orchestration-stub/package.json
@@ -45,5 +45,8 @@
     "unit-ci": "jest --ci --silent --colors --config jest.config.ci.ts --testLocationInResults",
     "unit:watch": "jest --watch"
   },
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "overrides": {
+    "uuid": ">=11.1.1"
+  }
 }


### PR DESCRIPTION
## What

- CVE-2026-41907: insufficient entropy in UUID v4 generation in uuid package. Adding override in orchestration-stub to constrain transitive uuid dependency to >=11.1.1 where the fix was released.

## How to review

1. Code Review