### PR TITLE
BAU: Remove unused jsonwebtoken from amc-stub

### DIFF
--- a/amc-stub/package.json
+++ b/amc-stub/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1063.0",
     "@aws-sdk/lib-dynamodb": "3.1063.0",
-    "jsonwebtoken": "9.0.2",
     "pino": "9.5.0",
     "jose": "6.2.2"
   },
@@ -32,7 +31,6 @@
     "@eslint/js": "10.0.1",
     "@types/aws-lambda": "8.10.154",
     "@types/chai": "5.2.3",
-    "@types/jsonwebtoken": "9.0.7",
     "@types/mocha": "10.0.10",
     "@types/node": "22.10.2",
     "@types/sinon": "21.0.1",


### PR DESCRIPTION
## What

- Remove `jsonwebtoken` from amc-stub dependencies and `@types/jsonwebtoken` from devDependencies
- The amc-stub uses `jose` for all JWT operations and never imports `jsonwebtoken` anywhere in its source code

## How to review

1. Code Review
2. Verify no compile/test failures