### PR TITLE
BAU: Update journey outcome structure

### DIFF
--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -185,7 +185,8 @@ function buildAMCOutcome(
 
   const action: AMCAction = {
     action: scope,
-    timestamp: Date.now(),
+    startedAt: Date.now(),
+    completedAt: Date.now(),
     success: isSuccess,
     details,
   };

--- a/amc-stub/src/types/types.ts
+++ b/amc-stub/src/types/types.ts
@@ -38,7 +38,8 @@ export interface AMCAuthorizationResult {
 
 export interface AMCAction {
   action: string;
-  timestamp: number;
+  startedAt: number;
+  completedAt: number;
   success: boolean;
   details: AMCActionErrorDetails | object;
 }

--- a/amc-stub/test/endpoints/amc-journey-outcome.test.ts
+++ b/amc-stub/test/endpoints/amc-journey-outcome.test.ts
@@ -21,7 +21,8 @@ describe("AMC Journey Outcome Stub Test", () => {
     actions: [
       {
         action: "account-delete",
-        timestamp: 1760718467000,
+        startedAt: 1760718467000,
+        completedAt: 1760718467000,
         success: true,
         details: {},
       },


### PR DESCRIPTION
Home have replaced timestamp with startedAt / completedAt: https://github.com/govuk-one-login/account-components/pull/970

None of our code reads the timestamp, so we should be able to make this change without doing any dance to deprecate a field.
