### PR TITLE
Aut 5641/ais response

### DIFF
--- a/amc-stub/scripts/encrypt-message-locally.ts
+++ b/amc-stub/scripts/encrypt-message-locally.ts
@@ -75,7 +75,7 @@ const createRequestJWT = async (scope: string) => {
   const sub = "urn:fdc:gov.uk:2022:fake_common_subject_identifier";
   const now = Math.floor(Date.now() / 1000);
   const requestPayload = {
-    iss: "https://signin.account.gov.uk",
+    iss: "auth",
     client_id: "auth",
     aud: "https://manage.account.gov.uk/authorize",
     response_type: "code",
@@ -86,7 +86,7 @@ const createRequestJWT = async (scope: string) => {
     iat: now,
     exp: now + 3600,
     nbf: now,
-    access_token: await createAccessToken(sub, scope),
+    account_data_api_access_token: await createAccessToken(sub, scope),
     sub: sub,
     public_sub: "550e8400-e29b-41d4-a716-446655440000",
     email: "test@digital.cabinet-office.gov.uk",
@@ -104,12 +104,14 @@ const createRequestJWT = async (scope: string) => {
     .setProtectedHeader({
       alg: JoseAlgorithms.RSA_OAEP_256,
       enc: JoseAlgorithms.A256GCM,
+      kid: "test-key-id",
     })
     .encrypt(publicKey);
 };
 const scope = process.argv[2];
 const encryptedRequest = await createRequestJWT(scope);
-const localUrl = `http://localhost:3000/authorize?request=${encryptedRequest}`;
+const redirectUri = "https://signin.account.gov.uk/{callback_endpoint}";
+const localUrl = `http://localhost:3000/authorize?request=${encryptedRequest}&scope=${scope}&redirect_uri=${encodeURIComponent(redirectUri)}`;
 
 console.log(`Encrypted request:\n${encryptedRequest}\n`);
 console.log(`Local Authorization URL:\n${localUrl}\n`);

--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -103,9 +103,13 @@ async function post(event: APIGatewayProxyEvent) {
     throw new CodedError(400, "Missing request body");
   }
 
-  const parsedBody = (event.body
-    ? Object.fromEntries(new URLSearchParams(event.body))
-    : {}) as unknown as ParsedBody;
+  const urlParams = new URLSearchParams(event.body);
+  const parsedBody = {
+    ...Object.fromEntries(urlParams),
+    "account-interventions": urlParams.getAll(
+      "account-interventions"
+    ) as AccountInterventionType[],
+  } as unknown as ParsedBody;
 
   const redirectUri = parsedBody["redirect_uri"];
   if (!redirectUri) {
@@ -165,7 +169,7 @@ function buildAMCOutcome(
   response: AMCAuthorizeResponse,
   email: string,
   scope: AMCScopes,
-  accountInterventions?: AccountInterventionType
+  accountInterventions?: AccountInterventionType[]
 ): AMCAuthorizationResult {
   const randomOutcomeId = base64url.encode(randomBytes(32));
   const isSuccess = response === "success";
@@ -193,9 +197,14 @@ function buildAMCOutcome(
 function buildErrorDetails(
   scope: AMCScopes,
   response: AMCAuthorizeResponse,
-  accountInterventions?: AccountInterventionType
+  accountInterventions?: AccountInterventionType[]
 ): AMCActionErrorDetails {
-  if (accountInterventions && accountInterventions !== "none") {
+  const hasInterventions =
+    accountInterventions &&
+    accountInterventions.length > 0 &&
+    !accountInterventions.every((i) => i === "none");
+
+  if (hasInterventions) {
     return {
       error: {
         code: 1004,
@@ -203,10 +212,10 @@ function buildErrorDetails(
       },
       accountInterventionsStatus: {
         state: {
-          blocked: accountInterventions === "blocked",
-          reproveIdentity: accountInterventions === "reprove-identity",
-          resetPassword: accountInterventions === "reset-password",
-          suspended: accountInterventions === "suspended",
+          blocked: accountInterventions.includes("blocked"),
+          reproveIdentity: accountInterventions.includes("reprove-identity"),
+          resetPassword: accountInterventions.includes("reset-password"),
+          suspended: accountInterventions.includes("suspended"),
         },
       },
     };

--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -206,6 +206,7 @@ const responseToErrorDescriptionMap: Record<
   Record<string, string>
 > = {
   [AMCScopes.PASSKEY_CREATE]: {
+    failure: "JourneyFailed",
     back: "UserBackedOutOfJourney",
     skip: "UserAbortedJourney",
   },

--- a/amc-stub/src/endpoints/amc-authorize.ts
+++ b/amc-stub/src/endpoints/amc-authorize.ts
@@ -15,7 +15,9 @@ import {
   AMCAuthorizationResult,
   AMCAuthorizeResponse,
   AMCAction,
+  AMCActionErrorDetails,
   ParsedBody,
+  AccountInterventionType,
 } from "../types/types.ts";
 import { putAMCAuthorizationResultWithAuthCode } from "../../services/dynamodb-service.ts";
 
@@ -125,7 +127,8 @@ async function post(event: APIGatewayProxyEvent) {
     parsedBody.sub,
     parsedBody.response,
     parsedBody.email,
-    parsedBody.scope
+    parsedBody.scope,
+    parsedBody["account-interventions"]
   );
 
   try {
@@ -161,34 +164,20 @@ function buildAMCOutcome(
   sub: string,
   response: AMCAuthorizeResponse,
   email: string,
-  scope: AMCScopes
+  scope: AMCScopes,
+  accountInterventions?: AccountInterventionType
 ): AMCAuthorizationResult {
   const randomOutcomeId = base64url.encode(randomBytes(32));
   const isSuccess = response === "success";
-
-  let details = {};
-  if (!isSuccess) {
-    const errorDescription = responseToErrorDescriptionMap[scope]?.[response];
-    if (!errorDescription) {
-      throw new CodedError(
-        500,
-        `Cannot find error description for response: ${response}`
-      );
-    }
-    details = {
-      error: {
-        code: 1001,
-        description: errorDescription,
-      },
-    };
-  }
 
   const action: AMCAction = {
     action: scope,
     startedAt: Date.now(),
     completedAt: Date.now(),
     success: isSuccess,
-    details,
+    details: isSuccess
+      ? {}
+      : buildErrorDetails(scope, response, accountInterventions),
   };
 
   return {
@@ -201,14 +190,56 @@ function buildAMCOutcome(
   };
 }
 
-const responseToErrorDescriptionMap: Record<
-  AMCScopes,
-  Record<string, string>
-> = {
-  [AMCScopes.PASSKEY_CREATE]: {
-    failure: "JourneyFailed",
-    back: "UserBackedOutOfJourney",
-    skip: "UserAbortedJourney",
-  },
-  [AMCScopes.ACCOUNT_DELETE]: {},
-};
+function buildErrorDetails(
+  scope: AMCScopes,
+  response: AMCAuthorizeResponse,
+  accountInterventions?: AccountInterventionType
+): AMCActionErrorDetails {
+  if (accountInterventions && accountInterventions !== "none") {
+    return {
+      error: {
+        code: 1004,
+        description: "AccountHasInterventions",
+      },
+      accountInterventionsStatus: {
+        state: {
+          blocked: accountInterventions === "blocked",
+          reproveIdentity: accountInterventions === "reprove-identity",
+          resetPassword: accountInterventions === "reset-password",
+          suspended: accountInterventions === "suspended",
+        },
+      },
+    };
+  }
+
+  const errorDescription = getErrorDescription(scope, response);
+  return {
+    error: {
+      code: 1001,
+      description: errorDescription,
+    },
+  };
+}
+
+function getErrorDescription(
+  scope: AMCScopes,
+  response: AMCAuthorizeResponse
+): string {
+  const descriptions: Record<AMCScopes, Record<string, string>> = {
+    [AMCScopes.PASSKEY_CREATE]: {
+      failure: "JourneyFailed",
+      back: "UserBackedOutOfJourney",
+      skip: "UserAbortedJourney",
+    },
+    [AMCScopes.ACCOUNT_DELETE]: {},
+  };
+
+  const description = descriptions[scope]?.[response];
+  if (!description) {
+    throw new CodedError(
+      500,
+      `Cannot find error description for response: ${response}`
+    );
+  }
+  return description;
+}

--- a/amc-stub/src/endpoints/render-amc-authorize.ts
+++ b/amc-stub/src/endpoints/render-amc-authorize.ts
@@ -56,7 +56,7 @@ export default function renderAmcAuthorize(
   </fieldset>
   </div>
 
-  ${scope === AMCScopes.PASSKEY_CREATE ? getAccountInterventionTypeRadios() : ""}
+  ${scope === AMCScopes.PASSKEY_CREATE ? getAccountInterventionTypeCheckboxes() : ""}
 
   <button name="continue" value="continue" class="govuk-button">Continue</button>
   <input type="hidden" name="state" value=${decodedPayload.state}>
@@ -112,7 +112,7 @@ function getAccountDeleteResults() {
   `;
 }
 
-function getAccountInterventionTypeRadios() {
+function getAccountInterventionTypeCheckboxes() {
   return `
   <div class="govuk-form-group" id="account-interventions-group" style="display:none;">
   <fieldset class="govuk-fieldset">
@@ -121,29 +121,29 @@ function getAccountInterventionTypeRadios() {
             Account interventions type
         </h3>
     </legend>
-    <div class="govuk-hint">Optional. Only applies when response is not success.</div>
-    <div class="govuk-radios" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="account-interventions-blocked" name="account-interventions" type="radio" value="blocked" checked>
-            <label class="govuk-label govuk-radios__label" for="account-interventions-blocked">
+    <div class="govuk-hint">Optional. Select one or more. Only applies when response is not success.</div>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+        <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="account-interventions-blocked" name="account-interventions" type="checkbox" value="blocked">
+            <label class="govuk-label govuk-checkboxes__label" for="account-interventions-blocked">
                 Blocked
             </label>
         </div>
-        <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="account-interventions-reprove-identity" name="account-interventions" type="radio" value="reprove-identity">
-            <label class="govuk-label govuk-radios__label" for="account-interventions-reprove-identity">
+        <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="account-interventions-reprove-identity" name="account-interventions" type="checkbox" value="reprove-identity">
+            <label class="govuk-label govuk-checkboxes__label" for="account-interventions-reprove-identity">
                 Reprove identity
             </label>
         </div>
-        <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="account-interventions-reset-password" name="account-interventions" type="radio" value="reset-password">
-            <label class="govuk-label govuk-radios__label" for="account-interventions-reset-password">
+        <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="account-interventions-reset-password" name="account-interventions" type="checkbox" value="reset-password">
+            <label class="govuk-label govuk-checkboxes__label" for="account-interventions-reset-password">
                 Reset password
             </label>
         </div>
-        <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="account-interventions-suspended" name="account-interventions" type="radio" value="suspended">
-            <label class="govuk-label govuk-radios__label" for="account-interventions-suspended">
+        <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="account-interventions-suspended" name="account-interventions" type="checkbox" value="suspended">
+            <label class="govuk-label govuk-checkboxes__label" for="account-interventions-suspended">
                 Suspended
             </label>
         </div>

--- a/amc-stub/src/endpoints/render-amc-authorize.ts
+++ b/amc-stub/src/endpoints/render-amc-authorize.ts
@@ -55,6 +55,9 @@ export default function renderAmcAuthorize(
     </div>
   </fieldset>
   </div>
+
+  ${scope === AMCScopes.PASSKEY_CREATE ? getAccountInterventionTypeRadios() : ""}
+
   <button name="continue" value="continue" class="govuk-button">Continue</button>
   <input type="hidden" name="state" value=${decodedPayload.state}>
   <input type="hidden" name="sub" value=${decodedPayload.sub}>
@@ -72,6 +75,13 @@ function getPasskeyCreateResults() {
             <input class="govuk-radios__input" id="success" name="response" type="radio" value="success" checked>
             <label class="govuk-label govuk-radios__label" for="success">
                 Success
+            </label>
+        </div>
+        
+    <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="account-interventions-failure" name="response" type="radio" value="account-interventions-failure">
+            <label class="govuk-label govuk-radios__label" for="account-interventions-failure">
+                Account Interventions Failure
             </label>
         </div>
 
@@ -99,6 +109,62 @@ function getAccountDeleteResults() {
                 Success
             </label>
         </div>
+  `;
+}
+
+function getAccountInterventionTypeRadios() {
+  return `
+  <div class="govuk-form-group" id="account-interventions-group" style="display:none;">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h3 class="govuk-fieldset__heading">
+            Account interventions type
+        </h3>
+    </legend>
+    <div class="govuk-hint">Optional. Only applies when response is not success.</div>
+    <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="account-interventions-blocked" name="account-interventions" type="radio" value="blocked" checked>
+            <label class="govuk-label govuk-radios__label" for="account-interventions-blocked">
+                Blocked
+            </label>
+        </div>
+        <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="account-interventions-reprove-identity" name="account-interventions" type="radio" value="reprove-identity">
+            <label class="govuk-label govuk-radios__label" for="account-interventions-reprove-identity">
+                Reprove identity
+            </label>
+        </div>
+        <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="account-interventions-reset-password" name="account-interventions" type="radio" value="reset-password">
+            <label class="govuk-label govuk-radios__label" for="account-interventions-reset-password">
+                Reset password
+            </label>
+        </div>
+        <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="account-interventions-suspended" name="account-interventions" type="radio" value="suspended">
+            <label class="govuk-label govuk-radios__label" for="account-interventions-suspended">
+                Suspended
+            </label>
+        </div>
+    </div>
+  </fieldset>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var responseRadios = document.querySelectorAll('input[name="response"]');
+      var accountInterventionsGroup = document.getElementById('account-interventions-group');
+      function toggleAccountInterventionsGroup() {
+        var selected = document.querySelector('input[name="response"]:checked');
+        accountInterventionsGroup.style.display = (selected && selected.value === 'account-interventions-failure') ? '' : 'none';
+      }
+      responseRadios.forEach(function(radio) {
+        radio.addEventListener('change', toggleAccountInterventionsGroup);
+      });
+      toggleAccountInterventionsGroup();
+    });
+  </script>
   `;
 }
 

--- a/amc-stub/src/types/types.ts
+++ b/amc-stub/src/types/types.ts
@@ -86,7 +86,7 @@ export interface ParsedBody {
   redirect_uri: string;
   email: string;
   scope: AMCScopesValues;
-  "account-interventions"?: AccountInterventionType;
+  "account-interventions"?: AccountInterventionType[];
 }
 
 export interface JwksConfig {

--- a/amc-stub/src/types/types.ts
+++ b/amc-stub/src/types/types.ts
@@ -49,6 +49,14 @@ export interface AMCActionErrorDetails {
     code: number;
     description: string;
   };
+  accountInterventionsStatus?: {
+    state: {
+      blocked: boolean;
+      reproveIdentity: boolean;
+      resetPassword: boolean;
+      suspended: boolean;
+    };
+  };
 }
 
 type AMCScopesValues = (typeof AMCScopes)[keyof typeof AMCScopes];
@@ -64,6 +72,13 @@ export type AMCAuthorizeResponse =
   | PasskeysCreateResponse
   | AccountDeleteResponse;
 
+export type AccountInterventionType =
+  | "none"
+  | "blocked"
+  | "reprove-identity"
+  | "reset-password"
+  | "suspended";
+
 export interface ParsedBody {
   sub: string;
   response: AMCAuthorizeResponse;
@@ -71,6 +86,7 @@ export interface ParsedBody {
   redirect_uri: string;
   email: string;
   scope: AMCScopesValues;
+  "account-interventions"?: AccountInterventionType;
 }
 
 export interface JwksConfig {

--- a/amc-stub/test/endpoints/amc-authorize.test.ts
+++ b/amc-stub/test/endpoints/amc-authorize.test.ts
@@ -251,6 +251,72 @@ describe("AMC Authorize Stub Test", () => {
       }
     });
 
+    it("should return 302 and store account intervention details for failure with intervention", async () => {
+      const putStub = DynamoDBDocument.prototype.put as sinon.SinonStub;
+
+      const body = new URLSearchParams({
+        redirect_uri: "https://signin.account.gov.uk/callback",
+        state: "test-state-789",
+        sub: "urn:fdc:gov.uk:2022:test-subject",
+        response: "failure",
+        scope: "passkey-create",
+        email: "testuser@test.null.local",
+        "account-interventions": "suspended",
+      }).toString();
+
+      const event = createTestEvent(HttpMethod.POST, "/authorize", body);
+
+      const result = await handler(event);
+
+      expect(result.statusCode).to.eq(302);
+      expect(result.headers?.["Location"]).to.include("state=test-state-789");
+
+      const storedItem = putStub.firstCall.args[0].Item.authorization;
+      expect(storedItem.success).to.eq(false);
+      expect(storedItem.actions[0].success).to.eq(false);
+      expect(storedItem.actions[0].details.error.code).to.eq(1004);
+      expect(storedItem.actions[0].details.error.description).to.eq(
+        "AccountHasInterventions"
+      );
+      expect(
+        storedItem.actions[0].details.accountInterventionsStatus.state
+      ).to.deep.eq({
+        blocked: false,
+        reproveIdentity: false,
+        resetPassword: false,
+        suspended: true,
+      });
+    });
+
+    it("should return 302 with standard error when failure has no account intervention", async () => {
+      const putStub = DynamoDBDocument.prototype.put as sinon.SinonStub;
+
+      const body = new URLSearchParams({
+        redirect_uri: "https://signin.account.gov.uk/callback",
+        state: "test-state-101",
+        sub: "urn:fdc:gov.uk:2022:test-subject",
+        response: "failure",
+        scope: "passkey-create",
+        email: "testuser@test.null.local",
+        "account-interventions": "none",
+      }).toString();
+
+      const event = createTestEvent(HttpMethod.POST, "/authorize", body);
+
+      const result = await handler(event);
+
+      expect(result.statusCode).to.eq(302);
+
+      const storedItem = putStub.firstCall.args[0].Item.authorization;
+      expect(storedItem.success).to.eq(false);
+      expect(storedItem.actions[0].details.error.code).to.eq(1001);
+      expect(storedItem.actions[0].details.error.description).to.eq(
+        "JourneyFailed"
+      );
+      expect(storedItem.actions[0].details.accountInterventionsStatus).to.be
+        .undefined;
+    });
+
     it("should return 500 when failure response is invalid", async () => {
       const body = new URLSearchParams({
         redirect_uri: "https://signin.account.gov.uk/callback",

--- a/amc-stub/test/endpoints/amc-authorize.test.ts
+++ b/amc-stub/test/endpoints/amc-authorize.test.ts
@@ -254,15 +254,15 @@ describe("AMC Authorize Stub Test", () => {
     it("should return 302 and store account intervention details for failure with intervention", async () => {
       const putStub = DynamoDBDocument.prototype.put as sinon.SinonStub;
 
-      const body = new URLSearchParams({
-        redirect_uri: "https://signin.account.gov.uk/callback",
-        state: "test-state-789",
-        sub: "urn:fdc:gov.uk:2022:test-subject",
-        response: "failure",
-        scope: "passkey-create",
-        email: "testuser@test.null.local",
-        "account-interventions": "suspended",
-      }).toString();
+      const params = new URLSearchParams();
+      params.append("redirect_uri", "https://signin.account.gov.uk/callback");
+      params.append("state", "test-state-789");
+      params.append("sub", "urn:fdc:gov.uk:2022:test-subject");
+      params.append("response", "failure");
+      params.append("scope", "passkey-create");
+      params.append("email", "testuser@test.null.local");
+      params.append("account-interventions", "suspended");
+      const body = params.toString();
 
       const event = createTestEvent(HttpMethod.POST, "/authorize", body);
 
@@ -288,18 +288,56 @@ describe("AMC Authorize Stub Test", () => {
       });
     });
 
+    it("should return 302 and store multiple account intervention details for failure with multiple interventions", async () => {
+      const putStub = DynamoDBDocument.prototype.put as sinon.SinonStub;
+
+      const params = new URLSearchParams();
+      params.append("redirect_uri", "https://signin.account.gov.uk/callback");
+      params.append("state", "test-state-multi");
+      params.append("sub", "urn:fdc:gov.uk:2022:test-subject");
+      params.append("response", "failure");
+      params.append("scope", "passkey-create");
+      params.append("email", "testuser@test.null.local");
+      params.append("account-interventions", "blocked");
+      params.append("account-interventions", "suspended");
+      const body = params.toString();
+
+      const event = createTestEvent(HttpMethod.POST, "/authorize", body);
+
+      const result = await handler(event);
+
+      expect(result.statusCode).to.eq(302);
+      expect(result.headers?.["Location"]).to.include("state=test-state-multi");
+
+      const storedItem = putStub.firstCall.args[0].Item.authorization;
+      expect(storedItem.success).to.eq(false);
+      expect(storedItem.actions[0].success).to.eq(false);
+      expect(storedItem.actions[0].details.error.code).to.eq(1004);
+      expect(storedItem.actions[0].details.error.description).to.eq(
+        "AccountHasInterventions"
+      );
+      expect(
+        storedItem.actions[0].details.accountInterventionsStatus.state
+      ).to.deep.eq({
+        blocked: true,
+        reproveIdentity: false,
+        resetPassword: false,
+        suspended: true,
+      });
+    });
+
     it("should return 302 with standard error when failure has no account intervention", async () => {
       const putStub = DynamoDBDocument.prototype.put as sinon.SinonStub;
 
-      const body = new URLSearchParams({
-        redirect_uri: "https://signin.account.gov.uk/callback",
-        state: "test-state-101",
-        sub: "urn:fdc:gov.uk:2022:test-subject",
-        response: "failure",
-        scope: "passkey-create",
-        email: "testuser@test.null.local",
-        "account-interventions": "none",
-      }).toString();
+      const params = new URLSearchParams();
+      params.append("redirect_uri", "https://signin.account.gov.uk/callback");
+      params.append("state", "test-state-101");
+      params.append("sub", "urn:fdc:gov.uk:2022:test-subject");
+      params.append("response", "failure");
+      params.append("scope", "passkey-create");
+      params.append("email", "testuser@test.null.local");
+      params.append("account-interventions", "none");
+      const body = params.toString();
 
       const event = createTestEvent(HttpMethod.POST, "/authorize", body);
 
@@ -313,8 +351,9 @@ describe("AMC Authorize Stub Test", () => {
       expect(storedItem.actions[0].details.error.description).to.eq(
         "JourneyFailed"
       );
-      expect(storedItem.actions[0].details.accountInterventionsStatus).to.be
-        .undefined;
+      expect(storedItem.actions[0].details.accountInterventionsStatus).to.eq(
+        undefined
+      );
     });
 
     it("should return 500 when failure response is invalid", async () => {


### PR DESCRIPTION
AMC can return to auth in the create passkey journey with a response indicating that the user has an account intervention on their account.

This modifies the stub to allow for selecting an option which will return an intervention.

## Related Pull Requests

* [handling an account intervention response from amc on the frontend](https://github.com/govuk-one-login/authentication-frontend/pull/3532)
* [Adding the relevant acceptance test (to be merged after this one)](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/953)
